### PR TITLE
Add CLI options for embeddings utility

### DIFF
--- a/site/utils/embeddings/Makefile
+++ b/site/utils/embeddings/Makefile
@@ -1,5 +1,11 @@
 .PHONY: help lint test build
 
+INPUT_DIR ?= ../../src/content/posts
+OUTPUT_JSON ?= similarity_data.json
+CHUNK_SIZE ?= 256
+OVERLAP_SIZE ?= 32
+RELATED_COUNT ?= 10
+
 help:
 	@echo "install:         Install all the parts needed for local dev"
 	@echo "clean:           Completely clean everything up"
@@ -20,5 +26,10 @@ install:
 	. venv/bin/activate; pip install -r requirements.txt
 
 build: install
-	@echo "building related document file"
-	. venv/bin/activate; python make_embeddings.py
+        @echo "building related document file"
+        . venv/bin/activate; python make_embeddings.py \
+                --input $(INPUT_DIR) \
+                --output $(OUTPUT_JSON) \
+                --chunk-size $(CHUNK_SIZE) \
+                --overlap-size $(OVERLAP_SIZE) \
+                --related-count $(RELATED_COUNT)

--- a/site/utils/embeddings/README.md
+++ b/site/utils/embeddings/README.md
@@ -27,6 +27,23 @@ file and then the top 10 most similar objects related to it.
 To build the database run: `make build` and everything will generate. This might
 take up to 30 seconds.
 
+### Command line options
+
+`make_embeddings.py` accepts several flags so you can customise how the
+embedding data is produced:
+
+* `-i, --input` – directory containing markdown posts (default
+  `../../src/content/posts`)
+* `-o, --output` – where to write the JSON output (default
+  `similarity_data.json`)
+* `--chunk-size` – token count to use for each chunk (default `256`)
+* `--overlap-size` – number of overlapping tokens between chunks (default `32`)
+* `--related-count` – how many related posts to store per entry (default `10`)
+
+These values can also be overridden when running `make build` by setting the
+`INPUT_DIR`, `OUTPUT_JSON`, `CHUNK_SIZE`, `OVERLAP_SIZE` and `RELATED_COUNT`
+variables.
+
 ### Note when making new documents
 
 Currently there is no automated process for running this when a new content

--- a/site/utils/embeddings/make_embeddings.py
+++ b/site/utils/embeddings/make_embeddings.py
@@ -1,3 +1,4 @@
+import argparse
 import hashlib
 import json
 import os
@@ -53,69 +54,122 @@ def file_to_slug(file):
     slug = slug_with_ext[:-3]
     return slug
 
-md_path = '../../src/content/posts'
+def main():
+    parser = argparse.ArgumentParser(description="Generate related post embeddings")
+    parser.add_argument(
+        "-i",
+        "--input",
+        default="../../src/content/posts",
+        help="Directory containing markdown posts",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="similarity_data.json",
+        help="Path to write JSON similarity data",
+    )
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=256,
+        help="Token chunk size for embeddings",
+    )
+    parser.add_argument(
+        "--overlap-size",
+        type=int,
+        default=32,
+        help="Token overlap between chunks",
+    )
+    parser.add_argument(
+        "--related-count",
+        type=int,
+        default=10,
+        help="Number of related posts to keep",
+    )
 
-processed_texts_hashes = [{
-    'file': f,
-    'text': preprocess_markdown_file(os.path.join(md_path, f)),
-    'hash': compute_hash(open(os.path.join(md_path, f), 'r', encoding='utf-8').read())
-} for f in os.listdir(md_path) if f.endswith('.md') ]
+    args = parser.parse_args()
+
+    md_path = args.input
+
+    processed_texts_hashes = [
+        {
+            "file": f,
+            "text": preprocess_markdown_file(os.path.join(md_path, f)),
+            "hash": compute_hash(
+                open(os.path.join(md_path, f), "r", encoding="utf-8").read()
+            ),
+        }
+        for f in os.listdir(md_path)
+        if f.endswith(".md")
+    ]
 
 
-# build the embeddings from the documents.
-# Using the all MiniLM model as it seems to produce a good balance of size
-# and embedding complexity so that we get some decent similarity scoring.
-model = SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')
+    # build the embeddings from the documents.
+    # Using the all MiniLM model as it seems to produce a good balance of size
+    # and embedding complexity so that we get some decent similarity scoring.
+    model = SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')
 
-embeddings_list = [{
-    'file': item['file'],
-    'embedding': chunk_and_encode(item['text'], model),
-    'hash': item['hash']
-} for item in processed_texts_hashes]
+    embeddings_list = [
+        {
+            'file': item['file'],
+            'embedding': chunk_and_encode(
+                item['text'],
+                model,
+                chunk_size=args.chunk_size,
+                overlap_size=args.overlap_size,
+            ),
+            'hash': item['hash'],
+        }
+        for item in processed_texts_hashes
+    ]
 
-# Now we make the similarity matrix between each document.
+    # Now we make the similarity matrix between each document.
 
-# Create an array where each row is an embedding
-embeddings_array = np.array([item['embedding'] for item in embeddings_list])
+    # Create an array where each row is an embedding
+    embeddings_array = np.array([item['embedding'] for item in embeddings_list])
 
-# Compute the cosine similarity matrix
-similarity_matrix = cosine_similarity(embeddings_array, embeddings_array)
+    # Compute the cosine similarity matrix
+    similarity_matrix = cosine_similarity(embeddings_array, embeddings_array)
 
-# Initialize an empty list to hold the data
-data = []
+    # Initialize an empty list to hold the data
+    data = []
 
-# Iterate through each row of the similarity matrix
-for i, row in enumerate(similarity_matrix):
-    # Get the file name and hash for the current document
-    current_file = embeddings_list[i]['file']
-    current_hash = embeddings_list[i]['hash']
+    # Iterate through each row of the similarity matrix
+    for i, row in enumerate(similarity_matrix):
+        # Get the file name and hash for the current document
+        current_file = embeddings_list[i]['file']
+        current_hash = embeddings_list[i]['hash']
 
-    # Initialize an empty list to hold the similarity info for this document
-    post_similarity = []
+        # Initialize an empty list to hold the similarity info for this document
+        post_similarity = []
 
-    # Iterate through each column of the similarity matrix
-    for j, similarity_score in enumerate(row):
-        # Skip the diagonal (self-similarity) elements
-        if i != j:
-            related_file = embeddings_list[j]['file']
-            post_similarity.append({
-                'file': related_file,
-                'slug': file_to_slug(related_file),
-                'similarity': float(similarity_score)
-            })
+        # Iterate through each column of the similarity matrix
+        for j, similarity_score in enumerate(row):
+            # Skip the diagonal (self-similarity) elements
+            if i != j:
+                related_file = embeddings_list[j]['file']
+                post_similarity.append({
+                    'file': related_file,
+                    'slug': file_to_slug(related_file),
+                    'similarity': float(similarity_score)
+                })
 
-    # Sort the post_similarity list by similarity score in descending order
-    post_similarity = sorted(post_similarity, key=lambda x: x['similarity'], reverse=True)
+        # Sort the post_similarity list by similarity score in descending order
+        post_similarity = sorted(post_similarity, key=lambda x: x['similarity'], reverse=True)
 
-    # Create a dictionary for the current document and add it to the data list
-    data.append({
-        'file': current_file,
-        'slug': file_to_slug(current_file),
-        'hash': current_hash,
-        'post_similarity': post_similarity[0:10]
-    })
+        # Create a dictionary for the current document and add it to the data list
+        data.append({
+            'file': current_file,
+            'slug': file_to_slug(current_file),
+            'hash': current_hash,
+            'post_similarity': post_similarity[0:args.related_count]
+        })
 
-# Save the data to a JSON file
-with open('similarity_data.json', 'w') as f:
-    json.dump(data, f, indent=4)
+    # Save the data to a JSON file
+    with open(args.output, 'w') as f:
+        json.dump(data, f, indent=4)
+
+
+if __name__ == '__main__':
+    main()
 


### PR DESCRIPTION
## Summary
- add argparse support to `make_embeddings.py`
- allow Makefile to customise build via variables
- document new command line flags

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_682822ed18748325b9af08490d598bc1