### PR TITLE
Forward Accept/Prefer headers in CloudFront cache behavior

### DIFF
--- a/infra/application/cloudfront.tf
+++ b/infra/application/cloudfront.tf
@@ -7,10 +7,12 @@ resource "aws_cloudfront_cache_policy" "web_app_cache_policy" {
   name    = "ajfisher-web-app-cache-policy"
   comment = "Forward Accept and Prefer headers so Markdown and HTML variants stay isolated"
 
-  # Keep TTLs at zero so Lambda@Edge and origin headers exclusively control caching
+  # AWS requires caching be enabled (non-zero default/max TTL) to forward custom headers
+  # even though Lambda@Edge/origin response headers govern cache duration.
+  # Keep the window to 1s so CloudFront revalidates almost immediately.
   min_ttl     = 0
-  default_ttl = 0
-  max_ttl     = 0
+  default_ttl = 1
+  max_ttl     = 1
 
   parameters_in_cache_key_and_forwarded_to_origin {
     cookies_config {


### PR DESCRIPTION
## Summary
- ensure the default cache behavior forwards the Accept and Prefer headers so CloudFront produces distinct cache keys for markdown and HTML responses

## Testing
- `terraform fmt -recursive` *(fails: terraform binary not available in container and download attempts are blocked)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bb22aabb08325884110dde84c0ebe)