### PR TITLE
Add markdown alternate head directives

### DIFF
--- a/site/src/templates/article.js
+++ b/site/src/templates/article.js
@@ -8,13 +8,23 @@ import PageHead from '../components/page-head';
 // need to use object.assign here due to the way arrow functions get hoisted
 // with the export. As we need to add the proptypes to the object that gets
 // hoisted we need to do this in one step then export it.
+const buildMarkdownHref = (pathname = '') => {
+  if (!pathname) {
+    return null;
+  }
+
+  const normalizedPath = pathname.endsWith('/') ? pathname : `${pathname}/`;
+  return `${normalizedPath}index.md`;
+};
+
 export const Head = Object.assign(
-  ({_location, _params, data, _pageContext}) => {
+  ({location, _params, data, _pageContext}) => {
     const { markdownRemark} = data;
     const { frontmatter} = markdownRemark;
 
     const excerpt = frontmatter.excerpt || markdownRemark.excerpt || '';
     const twitter_excerpt = frontmatter.twitter_excerpt || excerpt;
+    const markdownHref = buildMarkdownHref(location?.pathname);
     return (
       <>
         <PageHead
@@ -23,12 +33,17 @@ export const Head = Object.assign(
           type="article"
           tweet={twitter_excerpt}
         />
+        {markdownHref && (
+          <link rel="alternate" type="text/markdown" href={markdownHref} />
+        )}
       </>
     );
   },
   {
     propTypes: {
-      _location: PropTypes.object,
+      location: PropTypes.shape({
+        pathname: PropTypes.string,
+      }),
       _params: PropTypes.object,
       data: PropTypes.shape({
         markdownRemark: PropTypes.shape({

--- a/site/src/templates/post.js
+++ b/site/src/templates/post.js
@@ -4,11 +4,20 @@ import { graphql } from 'gatsby';
 import Layout from '../components/post-layout';
 import PageHead from '../components/page-head';
 
+const buildMarkdownHref = (pathname = '') => {
+  if (!pathname) {
+    return null;
+  }
+
+  const normalizedPath = pathname.endsWith('/') ? pathname : `${pathname}/`;
+  return `${normalizedPath}index.md`;
+};
+
 // need to use object.assign here due to the way arrow functions get hoisted
 // with the export. As we need to add the proptypes to the object that gets
 // hoisted we need to do this in one step then export it.
 export const Head = Object.assign(
-  ({data}) => {
+  ({data, location}) => {
     const { markdownRemark} = data;
     const { frontmatter, timeToRead, wordCount} = markdownRemark;
 
@@ -16,6 +25,7 @@ export const Head = Object.assign(
     const twitter_excerpt = frontmatter.twitter_excerpt || excerpt;
 
     const featuredImage = frontmatter?.featureimage || '';
+    const markdownHref = buildMarkdownHref(location?.pathname);
 
     return (
       <>
@@ -28,6 +38,9 @@ export const Head = Object.assign(
           readingTime={timeToRead}
           words={wordCount.words}
         />
+        {markdownHref && (
+          <link rel="alternate" type="text/markdown" href={markdownHref} />
+        )}
       </>
     );
   },
@@ -48,6 +61,9 @@ export const Head = Object.assign(
           }).isRequired,
         }).isRequired,
       }).isRequired,
+      location: PropTypes.shape({
+        pathname: PropTypes.string,
+      }),
     }
   }
 );


### PR DESCRIPTION
## Summary
- add a helper that derives the markdown companion path from the current page pathname
- expose a `<link rel="alternate" type="text/markdown">` element from the page and post templates so clients learn about the markdown variant

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919b1d8b12483258bf15fbfe55a7a6d)