### PR TITLE
Add preview base path support for PR builds

### DIFF
--- a/site.v5/README.md
+++ b/site.v5/README.md
@@ -15,6 +15,20 @@ make install
 npm install
 ```
 
+## Preview builds (subpath)
+
+To build the site for a preview path such as `/pr-123/`, set `PREVIEW_BASE` when running the build:
+
+```bash
+PREVIEW_BASE=/pr-123/ make build
+# or
+PREVIEW_BASE=/preview-master/ npm run build
+```
+
+If `PREVIEW_BASE` is unset, the site builds normally for `/`.
+
+Optional: override `SITE_URL` too if you want canonical/sitemap generation to target a different host during preview builds.
+
 ## Common commands (Makefile)
 
 ```bash

--- a/site.v5/astro.config.mjs
+++ b/site.v5/astro.config.mjs
@@ -12,6 +12,18 @@ import { generateIcons } from './scripts/generate-icons.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+const normalizeBase = (value) => {
+  if (!value) return '/';
+  let v = String(value).trim();
+  if (!v || v === '/') return '/';
+  if (!v.startsWith('/')) v = `/${v}`;
+  if (!v.endsWith('/')) v = `${v}/`;
+  return v;
+};
+
+const previewBase = normalizeBase(process.env.PREVIEW_BASE);
+const siteUrl = new URL(previewBase, process.env.SITE_URL || 'https://ajfisher.me').toString();
+
 const iconGenerator = () => ({
   name: 'icon-generator',
   hooks: {
@@ -25,7 +37,8 @@ const iconGenerator = () => ({
 });
 
 export default defineConfig({
-  site: 'https://ajfisher.me',
+  site: siteUrl,
+  base: previewBase,
   srcDir: './src',
 
   // Static assets (favicons, etc) usually live in public/

--- a/site.v5/package-lock.json
+++ b/site.v5/package-lock.json
@@ -353,6 +353,7 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
       "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1146,6 +1147,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1168,6 +1170,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1190,6 +1193,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1206,6 +1210,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1222,6 +1227,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1238,6 +1244,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1254,6 +1261,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1270,6 +1278,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1286,6 +1295,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1302,6 +1312,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1318,6 +1329,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1334,6 +1346,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1350,6 +1363,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1372,6 +1386,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1394,6 +1409,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1416,6 +1432,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1438,6 +1455,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1460,6 +1478,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1482,6 +1501,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1504,6 +1524,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1526,6 +1547,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1545,6 +1567,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1564,6 +1587,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1583,6 +1607,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -9482,6 +9507,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "optional": true
     },

--- a/site.v5/src/components/Footer.astro
+++ b/site.v5/src/components/Footer.astro
@@ -45,13 +45,13 @@ const featuredImg = imageTransform(featured.data.listimage);
     <section>
       <h2>Recent Media</h2>
       <div class="image-link">
-        <a href={withBase('/2023/02/13/podcast-enterprise-ai/')}>
+        <a href={withBase('/2023/02/12/podcast-enterprise-ai/')}>
           <Image src={enterpriseAiImage} alt="Illustration of an office"
             width="750" height="300" position="center"/>
         </a>
       </div>
       <p>
-        <a href={withBase('/2023/02/13/podcast-enterprise-ai/')}>
+        <a href={withBase('/2023/02/12/podcast-enterprise-ai/')}>
           ChatGPT and Generative AI in the enterprise
         </a>
       </p>

--- a/site.v5/src/components/Footer.astro
+++ b/site.v5/src/components/Footer.astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import { Image } from 'astro:assets';
-import { imageTransform } from '../lib/utils.mjs';
+import { imageTransform, withBase } from '../lib/utils.mjs';
 import enterpriseAiImage from '../../../content/img/posts/enterprise_ai.jpg';
 import roboticsBookImage from '../../../content/img/posts/make_js_robots.jpg';
 import responsiveDesignImage from '../../../content/img/posts/responsive_design.jpg';
@@ -33,25 +33,25 @@ const featuredImg = imageTransform(featured.data.listimage);
     <section>
       <h2>Featured Post</h2>
       <div class="image-link">
-        <a href={`/${featured.data.uri}`}>
+        <a href={withBase(`/${featured.data.uri}`)}>
           <div class="image-wrapper"><Image src={featuredImg} alt={featured.data.title}
             width="750" height="400"/></div>
         </a>
       </div>
-      <p><a href={`/${featured.data.uri}`}>{featured.data.title}</a></p>
+      <p><a href={withBase(`/${featured.data.uri}`)}>{featured.data.title}</a></p>
       <p>{featured.data.excerpt}</p>
     </section>
 
     <section>
       <h2>Recent Media</h2>
       <div class="image-link">
-        <a href="/2023/02/13/podcast-enterprise-ai/">
+        <a href={withBase('/2023/02/13/podcast-enterprise-ai/')}>
           <Image src={enterpriseAiImage} alt="Illustration of an office"
             width="750" height="300" position="center"/>
         </a>
       </div>
       <p>
-        <a href="/2023/02/13/podcast-enterprise-ai/">
+        <a href={withBase('/2023/02/13/podcast-enterprise-ai/')}>
           ChatGPT and Generative AI in the enterprise
         </a>
       </p>

--- a/site.v5/src/components/ListItem.astro
+++ b/site.v5/src/components/ListItem.astro
@@ -4,7 +4,7 @@ import { Icon } from 'astro-icon/components';
 
 import humanize from 'humanize-plus';
 
-import { imageTransform, longDate } from '../lib/utils.mjs';
+import { imageTransform, longDate, withBase } from '../lib/utils.mjs';
 
 const {
   title = "This is a title",
@@ -36,7 +36,7 @@ const publishDate = (new Date(date)).toISOString().slice(0,10);
 ---
 <li class="listitem" itemscope="blogPost" itemtype="https://schema.org/BlogPosting">
   <div>
-    <a itemprop="url" href={`/${uri}`}>
+    <a itemprop="url" href={withBase(`/${uri}`)}>
       <Image src={imageTransform(image)} alt={title}
         layout="constrained"
         width="600" height="250" loading="lazy"/>
@@ -44,11 +44,11 @@ const publishDate = (new Date(date)).toISOString().slice(0,10);
   </div>
   { compact && (
     <p itemprop="headline">
-      <a href={`/${uri}`}>{title}</a>
+      <a href={withBase(`/${uri}`)}>{title}</a>
     </p>
   )}
   { !compact && (
-    <h3 itemprop="headline"><a href={`/${uri}`}>{title}</a></h3>
+    <h3 itemprop="headline"><a href={withBase(`/${uri}`)}>{title}</a></h3>
     <p class="postdate">
       <time itemprop="datePublished" datetime={publishDate}>{longDate(date)}</time></p>
     <p itemprop="abstract" itemtype="https://schema.org/CreativeWork">{excerpt}</p>

--- a/site.v5/src/components/Navigation.astro
+++ b/site.v5/src/components/Navigation.astro
@@ -1,12 +1,13 @@
 ---
 import { Icon } from 'astro-icon/components';
+import { withBase } from '../lib/utils.mjs';
 ---
 <ul>
-  <li><a href="/">Home</a></li>
-  <li><a href="/blog/">Article archive</a></li>
-  <li><a href="/who/">Who is @ajfisher</a></li>
-  <li><a href="/colophon/">Colophon</a></li>
-  <li><a href="/dis-everything/">Disclaimer & Disclosure</a></li>
+  <li><a href={withBase('/')}>Home</a></li>
+  <li><a href={withBase('/blog/')}>Article archive</a></li>
+  <li><a href={withBase('/who/')}>Who is @ajfisher</a></li>
+  <li><a href={withBase('/colophon/')}>Colophon</a></li>
+  <li><a href={withBase('/dis-everything/')}>Disclaimer & Disclosure</a></li>
   <li class="icons">
     <a  title="@ajfisher on Github"
         href="https://github.com/ajfisher"

--- a/site.v5/src/components/Pagination.astro
+++ b/site.v5/src/components/Pagination.astro
@@ -1,5 +1,6 @@
 ---
 import { Icon } from 'astro-icon/components';
+import { withBase } from '../lib/utils.mjs';
 
 const { page } = Astro.props;
 
@@ -16,14 +17,14 @@ for (let i = 1; i <= page.lastPage; i++) {
 ---
 <nav class="pagination" aria-label="Pagination navigation">
   { page.url.prev && (
-    <a href={page.url.prev} rel="prev">
+    <a href={withBase(page.url.prev)} rel="prev">
       <Icon name="fa7-solid:angle-left" />
     </a>
   )}
 
   { archivePages.map(archivePage => (
     <a
-      href={archivePage.uri}
+      href={withBase(archivePage.uri)}
       class={archivePage.current ? 'current' : ''}
       aria-current={archivePage.current ? 'page' : null}
     >
@@ -32,7 +33,7 @@ for (let i = 1; i <= page.lastPage; i++) {
   )) }
 
   { page.url.next && (
-    <a href={page.url.next} rel="next">
+    <a href={withBase(page.url.next)} rel="next">
       <Icon name="fa7-solid:angle-right" />
     </a>
   )}

--- a/site.v5/src/components/PostAttribution.astro
+++ b/site.v5/src/components/PostAttribution.astro
@@ -1,5 +1,5 @@
 ---
-import { longDate } from '../lib/utils.mjs';
+import { longDate, withBase } from '../lib/utils.mjs';
 
 const {
   title = "This is a title",
@@ -11,7 +11,8 @@ const {
   tags = [],
 } = Astro.props;
 
-const pageurl = `https://ajfisher.me/${uri}`;
+const siteUrl = Astro.site ?? 'https://ajfisher.me';
+const pageurl = new URL(withBase(`/${uri}`), siteUrl).toString();
 
 const attributes = [
   { label: 'Title', value: `"${title}"` },
@@ -33,7 +34,7 @@ const attributes = [
       <dt class="displaysmall">Tags</dt>
       <dd class="displaysmall">
         {tags.map((tag) => (
-          <Fragment><a href=`/tagged/${tag.slug}/`>{tag.name}</a> </Fragment>
+          <Fragment><a href={withBase(`/tagged/${tag.slug}/`)}>{tag.name}</a> </Fragment>
         ))}
 
       </dd>

--- a/site.v5/src/components/Tags.astro
+++ b/site.v5/src/components/Tags.astro
@@ -1,5 +1,5 @@
 ---
-import { slugifyTag } from '../lib/utils.mjs';
+import { slugifyTag, withBase } from '../lib/utils.mjs';
 
 const {
   tags = [],
@@ -22,7 +22,7 @@ if (tags && tags.length > 0) {
   <p>Tags:</p>
   <p class="tags">
     {tags.map(tag => (
-      <a href=`/tagged/${tag.slug}/`>{tag.name}</a>
+      <a href={withBase(`/tagged/${tag.slug}/`)}>{tag.name}</a>
     ))}
   </p>
 )}

--- a/site.v5/src/layouts/BaseLayout.astro
+++ b/site.v5/src/layouts/BaseLayout.astro
@@ -9,7 +9,7 @@ import humanize from 'humanize-plus';
 import SlideshowAssets from '../components/SlideshowAssets.astro';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
-import { imageTransform } from '../lib/utils.mjs';
+import { imageTransform, withBase } from '../lib/utils.mjs';
 import { ICON_SIZES, faviconPath, iconPath } from '../lib/icon-meta.mjs';
 import { SITE_META } from '../lib/site-meta.mjs';
 
@@ -83,15 +83,15 @@ const metaTags = [
 ].concat(extraMeta).concat(cardMeta);
 
 const canonical = siteUrl ? new URL(Astro.url.pathname, siteUrl).toString() : undefined;
-const sitemapUrl = siteUrl ? new URL('/sitemap-index.xml', siteUrl).toString() : '/sitemap-index.xml';
-const rssUrl = siteUrl ? new URL('/rss.xml', siteUrl).toString() : '/rss.xml';
+const sitemapUrl = siteUrl ? new URL(withBase('/sitemap-index.xml'), siteUrl).toString() : withBase('/sitemap-index.xml');
+const rssUrl = siteUrl ? new URL(withBase('/rss.xml'), siteUrl).toString() : withBase('/rss.xml');
 ---
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="theme-color" content="#FF5E9A" />
-    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="manifest" href={withBase('/manifest.webmanifest')} />
     <link rel="icon" type="image/png" href={faviconPath} />
     {ICON_SIZES.map((size) => (
       <link rel="apple-touch-icon" sizes={`${size}x${size}`} href={iconPath(size)} />

--- a/site.v5/src/lib/icon-meta.mjs
+++ b/site.v5/src/lib/icon-meta.mjs
@@ -1,7 +1,15 @@
 export const ICON_SIZES = [48, 72, 96, 144, 192, 256, 384, 512];
 export const FAVICON_SIZE = 32;
+const BASE_URL = import.meta.env.BASE_URL || '/';
+const withBase = (val = '/') => {
+  const base = BASE_URL.endsWith('/') ? BASE_URL.slice(0, -1) : BASE_URL;
+  const path = String(val || '/');
+  if (!path || path === '/') return base || '/';
+  const normalized = path.startsWith('/') ? path : `/${path}`;
+  return `${base}${normalized}` || normalized;
+};
 
 export const iconFileName = (size) => `icon-${size}x${size}.png`;
-export const iconPath = (size) => `/icons/${iconFileName(size)}`;
+export const iconPath = (size) => withBase(`/icons/${iconFileName(size)}`);
 export const faviconFileName = `favicon-${FAVICON_SIZE}x${FAVICON_SIZE}.png`;
-export const faviconPath = `/${faviconFileName}`;
+export const faviconPath = withBase(`/${faviconFileName}`);

--- a/site.v5/src/lib/utils.mjs
+++ b/site.v5/src/lib/utils.mjs
@@ -1,5 +1,16 @@
 // A set of utility functions for various common tasks
 
+export const basePath = import.meta.env.BASE_URL || '/';
+
+export const withBase = (val = '/') => {
+  const base = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
+  const path = String(val || '/');
+  if (!path || path === '/') return base || '/';
+  if (/^https?:\/\//.test(path) || path.startsWith('mailto:')) return path;
+  const normalized = path.startsWith('/') ? path : `/${path}`;
+  return `${base}${normalized}` || normalized;
+};
+
 // allows to transform image URLs to a format that suits astro set up on images
 export const imageTransform = (val) => {
   if (!val) return val;
@@ -12,6 +23,10 @@ export const imageTransform = (val) => {
   // get rid of relative paths in image URLs
   let transformed = val.replace('../../img/', '/img/');
   transformed = transformed.replace('../img/', '/img/');
+
+  if (transformed.startsWith('/img/')) {
+    return withBase(transformed);
+  }
 
   return transformed;
 }

--- a/site.v5/src/pages/404.astro
+++ b/site.v5/src/pages/404.astro
@@ -1,4 +1,5 @@
 ---
+import { withBase } from '../lib/utils.mjs';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Header from '../components/Header.astro';
 import notFoundImage from '../../../content/img/posts/404_page.png';
@@ -33,15 +34,15 @@ const seo = {
 
     <h2>Where to next?</h2>
     <p>
-      1. <a href="/">Go to the home page</a>: Check out recent articles
+      1. <a href={withBase('/')}>Go to the home page</a>: Check out recent articles
       and featured content.
     </p>
     <p>
-      2. <a href="/who/">Learn more about ajfisher</a>: Find out what I
+      2. <a href={withBase('/who/')}>Learn more about ajfisher</a>: Find out what I
       do and how I do it.
     </p>
     <p>
-      3. <a href="/blog/">Explore all articles</a>: Peruse the complete
+      3. <a href={withBase('/blog/')}>Explore all articles</a>: Peruse the complete
       archive of published content.
     </p>
   </section>

--- a/site.v5/src/pages/[...path].astro
+++ b/site.v5/src/pages/[...path].astro
@@ -7,7 +7,7 @@ import PostAttribution from '../components/PostAttribution.astro';
 import PostData from '../components/PostData.astro';
 import RelatedPosts from '../components/RelatedPosts.astro';
 
-import { imageTransform } from '../lib/utils.mjs';
+import { imageTransform, withBase } from '../lib/utils.mjs';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts');
@@ -36,13 +36,13 @@ const buildMarkdownHref = (entryData, entryCollection) => {
     const parts = uri.split('/');
     if (parts.length === 4) {
       const [year, month, day, slug] = parts;
-      return `/text/posts/${year}-${month}-${day}-${slug}.md`;
+      return withBase(`/text/posts/${year}-${month}-${day}-${slug}.md`);
     }
     return undefined;
   }
 
   if (entryCollection === 'pages') {
-    return `/text/pages/${uri}.md`;
+    return withBase(`/text/pages/${uri}.md`);
   }
 
   return undefined;

--- a/site.v5/src/pages/aieng.astro
+++ b/site.v5/src/pages/aieng.astro
@@ -1,4 +1,5 @@
 ---
+import { withBase } from '../lib/utils.mjs';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Header from '../components/Header.astro';
 import PostAttribution from '../components/PostAttribution.astro';
@@ -151,9 +152,9 @@ const seo = {
       <a href="https://tally.so/r/3xW4gv"> survey</a> I&apos;m running to
       understand how teams are using AI in practice today. It only take a few
       minutes and I would really appreciate it.</p>
-    <p>The <a href="/">home page</a> will give you featured
+    <p>The <a href={withBase('/')}>home page</a> will give you featured
       articles and recent posts.</p>
-    <p>You can also check out <a href="/blog/">the full
+    <p>You can also check out <a href={withBase('/blog/')}>the full
       list of articles</a> that have ever been published.</p>
 
   </section>

--- a/site.v5/src/pages/index.astro
+++ b/site.v5/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import { withBase } from '../lib/utils.mjs';
 // @ts-nocheck
 import { getCollection } from 'astro:content';
 
@@ -60,7 +61,7 @@ const headerData = headerPost ? mergeEntryData(headerPost) : {};
     <h2>Recent posts</h2>
     <ListItems items={recent} />
 
-    <p><a href="/blog/">See all posts</a></p>
+    <p><a href={withBase('/blog/')}>See all posts</a></p>
   </section>
 </BaseLayout>
 

--- a/site.v5/src/pages/leaders.astro
+++ b/site.v5/src/pages/leaders.astro
@@ -1,4 +1,5 @@
 ---
+import { withBase } from '../lib/utils.mjs';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Header from '../components/Header.astro';
 import PostAttribution from '../components/PostAttribution.astro';
@@ -110,9 +111,9 @@ const seo = {
 
     <h3>Where to next?</h3>
 
-    <p>The <a href="/">home page</a> will give you featured
+    <p>The <a href={withBase('/')}>home page</a> will give you featured
       articles and recent posts.</p>
-    <p>You can also check out <a href="/blog/">the full
+    <p>You can also check out <a href={withBase('/blog/')}>the full
       list of articles</a> that have ever been published.</p>
 
   </section>

--- a/site.v5/src/pages/manifest.webmanifest.js
+++ b/site.v5/src/pages/manifest.webmanifest.js
@@ -1,11 +1,12 @@
 import { ICON_SIZES, iconPath } from '../lib/icon-meta.mjs';
+import { basePath } from '../lib/utils.mjs';
 
 export const prerender = true;
 
 const MANIFEST = {
   name: 'ajfisher website',
   short_name: 'ajfisher',
-  start_url: '/',
+  start_url: basePath,
   display: 'minimal-ui',
   background_color: '#FF5E9A',
   theme_color: '#FF5E9A',


### PR DESCRIPTION
Closes #473

## Summary
Add support for building `ajfisher.me` under a configurable preview base path so we can serve LAN-hosted PR previews at URLs like `/pr-123/`.

## What changed
- added `PREVIEW_BASE` support in Astro config
- made preview-aware path handling available via shared helpers
- updated internal nav/content-derived links to respect the preview base
- updated manifest/icon paths for preview builds
- documented preview build usage in the README

## Validated locally
Built locally on Pi with:

```bash
PREVIEW_BASE=/pr-999-test/ make build
```

Then served locally under:
- `/pr-999-test/`

Checked successfully:
- home page
- deep article page
- archive page
- tag page
- major internal navigation/assets

## Why
This is the app-side unlock needed before building the Raspberry Pi PR preview swarm/controller.
