### PR TITLE
[codex] Allow same-origin animation framing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help:
 	@echo "dev:             Run the Astro development server"
 	@echo "preview:         Preview the production build"
 	@echo "lint:            Lint the site"
-	@echo "test:            Run lint and Astro type checks"
+	@echo "test:            Run app tests, lint, and Astro type checks"
 	@echo "pre-commit:      Run lint for site"
 	@echo "embeddings:      Run the embeddings similarity script"
 	@echo "build:           Build the site for deploy"
@@ -39,6 +39,7 @@ lint:
 	cd ./site.v5 && make lint
 
 test:
+	node --test app/tests/*.test.mjs
 	cd ./site.v5 && make test
 
 dev:

--- a/app/handlers/security_cache_headers.mjs
+++ b/app/handlers/security_cache_headers.mjs
@@ -8,8 +8,10 @@ export const handler = async (event) => {
   const request = event.Records[0].cf.request;
   const response = event.Records[0].cf.response;
   const headers = response.headers;
+  const uri = request.uri;
+  const frameOptions = uri.startsWith('/animation/') ? 'SAMEORIGIN' : 'DENY';
 
-  if (request.uri.startsWith('/static/')) {
+  if (uri.startsWith('/static/')) {
     headers['cache-control'] = [
       {
         key: 'Cache-Control',
@@ -26,7 +28,6 @@ export const handler = async (event) => {
       ];
     } else {
       let cache = false;
-      const uri = request.uri;
       if (uri.startsWith('/styles-') && uri.endsWith('.css')) {
         // cache built CSS files
         cache = true;
@@ -81,7 +82,7 @@ export const handler = async (event) => {
     },
     {
       key: 'X-Frame-Options',
-      value: 'deny'
+      value: frameOptions
     },
     {
       key: 'X-XSS-Protection',

--- a/app/tests/security_cache_headers.test.mjs
+++ b/app/tests/security_cache_headers.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { handler } from '../handlers/security_cache_headers.mjs';
+
+const eventFor = (uri) => ({
+  Records: [
+    {
+      cf: {
+        request: { uri },
+        response: { headers: {} }
+      }
+    }
+  ]
+});
+
+test('denies framing for normal pages', async () => {
+  const response = await handler(eventFor('/2026/06/13/fail-fast-fix-faster/'));
+
+  assert.equal(response.headers['x-frame-options'][0].value, 'DENY');
+});
+
+test('allows same-origin framing for animation assets', async () => {
+  const response = await handler(
+    eventFor('/animation/aieng26/terminal-stream.html')
+  );
+
+  assert.equal(response.headers['x-frame-options'][0].value, 'SAMEORIGIN');
+});


### PR DESCRIPTION
## Summary

- Allow `/animation/...` responses to use `X-Frame-Options: SAMEORIGIN` instead of the default `DENY`.
- Keep the `DENY` framing policy for normal site pages.
- Add Node tests for the Lambda@Edge header handler and wire them into the root `make test` target.

## Root cause

The two embedded animation iframes on the Fail fast, fix faster post load same-site HTML assets from `/animation/aieng26/...`. Those assets were being served correctly, but the global Lambda@Edge security header set `X-Frame-Options: deny` on every response, so the browser refused to display them in the page.

## Validation

- `make test`

The Astro check still reports the existing type hints, but no errors.