### PR TITLE
chore(ci): run Astro build on Node 22

### DIFF
--- a/.github/workflows/astro.build.yml
+++ b/.github/workflows/astro.build.yml
@@ -14,7 +14,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
 
             - name: Cache site node modules
               id: cache-sitev5-modules


### PR DESCRIPTION
## Summary
- Update the Astro build workflow to use Node 22 instead of Node 20.
- Keep the Lambda@Edge runtime unchanged, since #494 is only about the site build workflow.

## Why
Fixes #494. Astro 6 requires Node >=22.12.0, and the Dependabot Astro 6 PR currently fails because `.github/workflows/astro.build.yml` installs Node 20.

## Validation
- `make test`
- `make build`