### PR TITLE
chore(astro): migrate markdown processor config

### DIFF
--- a/site.v5/astro.config.mjs
+++ b/site.v5/astro.config.mjs
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { defineConfig } from 'astro/config';
+import { unified } from '@astrojs/markdown-remark';
 import icon from "astro-icon";
 import sitemap from '@astrojs/sitemap';
 import rehypeRaw from 'rehype-raw';
@@ -36,8 +37,10 @@ export default defineConfig({
   },
   trailingSlash: 'always',
   markdown: {
-    remarkPlugins: [remarkPullQuotes, remarkSlideshow, remarkReadingTime],
-    rehypePlugins: [rehypeRaw],
+    processor: unified({
+      remarkPlugins: [remarkPullQuotes, remarkSlideshow, remarkReadingTime],
+      rehypePlugins: [rehypeRaw],
+    }),
   },
   integrations: [
     icon(),


### PR DESCRIPTION
## Summary
- Move Astro markdown plugins from deprecated `markdown.remarkPlugins` / `markdown.rehypePlugins` fields to `markdown.processor`.
- Use `unified({ ... })` from `@astrojs/markdown-remark`.
- Preserve the existing pullquote, slideshow, reading-time, and raw HTML markdown plugin pipeline.

## Why
Fixes #497. Astro 6 warns that the old markdown plugin config is deprecated and will be removed in a future major.

## Validation
- `cd site.v5 && make check`
- `cd site.v5 && make build`
- `make test`
- Checked generated HTML for pullquote markup, slideshow carousel markup, and reading-time / word-count output.