### PR TITLE
chore(deps): remove unused site zod dependency

### DIFF
--- a/site.v5/package-lock.json
+++ b/site.v5/package-lock.json
@@ -17,8 +17,7 @@
         "install": "^0.13.0",
         "mdast-util-to-string": "^4.0.0",
         "rehype-raw": "^7.0.0",
-        "unist-util-visit": "^5.0.0",
-        "zod": "^3.25.76"
+        "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.6",

--- a/site.v5/package.json
+++ b/site.v5/package.json
@@ -20,8 +20,7 @@
     "install": "^0.13.0",
     "mdast-util-to-string": "^4.0.0",
     "rehype-raw": "^7.0.0",
-    "unist-util-visit": "^5.0.0",
-    "zod": "^3.25.76"
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.6",


### PR DESCRIPTION
## Summary
- Remove the unused direct `zod` dependency from `site.v5/package.json`.
- Regenerate `site.v5/package-lock.json` so only integration-owned Zod versions remain.
- Leave the content schema importing Zod through `astro/zod`.

## Why
Fixes #499. Astro 6 and the Astro integrations now manage their own compatible Zod versions, and the app code does not import `zod` directly.

## Validation
- `rg "from ['\"]zod|require\(['\"]zod" site.v5` returned no app imports.
- `npm ls zod` shows Astro/RSS on Zod 4 and sitemap on its own Zod 3-compatible dependency, with no direct root Zod dependency.
- `cd site.v5 && make check`
- `cd site.v5 && make build`
- Targeted generated-artifact assertions over `rss.xml`, `sitemap-index.xml`, `sitemap-0.xml`, `manifest.webmanifest`, built head links, package metadata, and the `astro/zod` content schema import.
- `make test`