### PR TITLE
feat: add post scaffold CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-site clean clean-site clean-meta dev preview lint test pre-commit build deploy
+.PHONY: help install install-site clean clean-site clean-meta dev preview post lint test pre-commit build deploy
 
 help:
 	@echo "install:         Install site dependencies"
@@ -8,8 +8,9 @@ help:
 	@echo "clean-meta:      Remove stale root node_modules"
 	@echo "dev:             Run the Astro development server"
 	@echo "preview:         Preview the production build"
+	@echo "post:            Scaffold a new post"
 	@echo "lint:            Lint the site"
-	@echo "test:            Run app tests, lint, and Astro type checks"
+	@echo "test:            Run app tests, script tests, lint, and Astro type checks"
 	@echo "pre-commit:      Run lint for site"
 	@echo "embeddings:      Run the embeddings similarity script"
 	@echo "build:           Build the site for deploy"
@@ -46,6 +47,9 @@ dev:
 
 preview:
 	cd ./site.v5 && make preview
+
+post:
+	npm run new-post -- $(ARGS)
 
 embeddings:
 	cd ./utils/embeddings && make build

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ Start the development server with:
 make dev
 ```
 
+Create a new post scaffold with:
+
+```bash
+npm run new-post
+# or
+npm run new-post -- --title "My Post" --tags "ai, development"
+# or
+make post
+```
+
 ## Build
 
 To generate the production build run:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "AJ Fisher website",
   "main": "index.js",
   "scripts": {
+    "new-post": "node site.v5/scripts/new-post.mjs",
     "test": "make test"
   },
   "repository": {

--- a/site.v5/Makefile
+++ b/site.v5/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install clean clean-build clean-deps dev build preview lint sync check test
+.PHONY: help install clean clean-build clean-deps dev build preview post lint sync check script-test test
 
 help:
 	@echo "install:         Install dependencies"
@@ -8,10 +8,12 @@ help:
 	@echo "dev:             Run the Astro development server"
 	@echo "build:           Build the site"
 	@echo "preview:         Preview the production build"
+	@echo "post:            Scaffold a new post"
 	@echo "lint:            Run ESLint"
 	@echo "sync:            Sync Astro content collections/types"
 	@echo "check:           Run Astro type check"
-	@echo "test:            Run lint and type check"
+	@echo "script-test:     Run Node script tests"
+	@echo "test:            Run script tests, lint, and type check"
 
 install:
 	@echo "Installing dependencies"
@@ -36,6 +38,9 @@ build:
 preview:
 	npm run preview
 
+post:
+	npm run new-post -- $(ARGS)
+
 lint:
 	npm run lint
 
@@ -45,4 +50,7 @@ sync:
 check:
 	./node_modules/.bin/astro check
 
-test: lint check
+script-test:
+	node --test scripts/*.test.mjs
+
+test: script-test lint check

--- a/site.v5/README.md
+++ b/site.v5/README.md
@@ -21,10 +21,11 @@ npm install
 make dev        # Start the Astro dev server
 make build      # Build the production site (outputs to dist/)
 make preview    # Preview the production build
+make post       # Scaffold a new post
 make lint       # Run ESLint
 make sync       # Sync Astro content collections/types
 make check      # Run Astro type check
-make test       # Run lint + type check
+make test       # Run script tests + lint + type check
 ```
 
 ## npm scripts and Astro CLI
@@ -33,10 +34,18 @@ make test       # Run lint + type check
 npm run dev
 npm run build
 npm run preview
+npm run new-post
 npm run lint
 
 npx astro sync
 npx astro check
+```
+
+From the repository root, the preferred post scaffold command is:
+
+```bash
+npm run new-post
+npm run new-post -- --title "My Post" --tags "ai, development"
 ```
 
 ## Content and assets

--- a/site.v5/README.md
+++ b/site.v5/README.md
@@ -48,6 +48,10 @@ npm run new-post
 npm run new-post -- --title "My Post" --tags "ai, development"
 ```
 
+The scaffold filename uses the same UTC date basis as generated post URLs, so
+early-morning local dates with a positive timezone offset may produce a previous
+day filename to keep source links aligned.
+
 ## Content and assets
 
 - Static assets are served from `../content` because `publicDir` is mapped

--- a/site.v5/package.json
+++ b/site.v5/package.json
@@ -7,6 +7,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
+    "new-post": "node scripts/new-post.mjs",
     "lint": "npx eslint ."
   },
   "author": "",

--- a/site.v5/scripts/new-post.mjs
+++ b/site.v5/scripts/new-post.mjs
@@ -42,17 +42,59 @@ export const normalizeTags = (tags = '') => String(tags ?? '')
   .filter(Boolean)
   .join(', ');
 
-export const datePrefixFromPostDate = (date) => {
+const parsePostDate = (date) => {
   const dateString = String(date ?? '');
-  const match = dateString.match(/^(\d{4})-(\d{2})-(\d{2})(?:\s|T|$)/);
+  const match = dateString.match(
+    /^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2}):(\d{2})(Z|[+-]\d{2}:\d{2}))?$/,
+  );
 
-  if (!match || Number.isNaN(Date.parse(dateString.replace(' ', 'T')))) {
+  if (!match) {
     throw new Error(
-      'Date must begin with YYYY-MM-DD and be parseable by JavaScript Date.',
+      'Date must be YYYY-MM-DD or YYYY-MM-DD HH:mm:ss+tz.',
     );
   }
 
-  return `${match[1]}-${match[2]}-${match[3]}`;
+  const [, yearValue, monthValue, dayValue, hourValue, minuteValue, secondValue] =
+    match;
+  const year = Number(yearValue);
+  const month = Number(monthValue);
+  const day = Number(dayValue);
+  const calendarDate = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    calendarDate.getUTCFullYear() !== year
+    || calendarDate.getUTCMonth() !== month - 1
+    || calendarDate.getUTCDate() !== day
+  ) {
+    throw new Error('Date must contain a valid calendar day.');
+  }
+
+  if (hourValue !== undefined) {
+    const hour = Number(hourValue);
+    const minute = Number(minuteValue);
+    const second = Number(secondValue);
+
+    if (hour > 23 || minute > 59 || second > 59) {
+      throw new Error('Date time must contain a valid clock time.');
+    }
+  }
+
+  const parsedDate = new Date(dateString.replace(' ', 'T'));
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    throw new Error('Date must be parseable by JavaScript Date.');
+  }
+
+  return parsedDate;
+};
+
+export const datePrefixFromPostDate = (date) => {
+  const parsedDate = parsePostDate(date);
+  const year = parsedDate.getUTCFullYear();
+  const month = pad(parsedDate.getUTCMonth() + 1);
+  const day = pad(parsedDate.getUTCDate());
+
+  return `${year}-${month}-${day}`;
 };
 
 const quoteYamlString = (value) => JSON.stringify(value);
@@ -69,7 +111,7 @@ export const renderPostMarkdown = ({ title, date, slug, tags }) => {
   ];
 
   if (normalizedTags) {
-    lines.push(`tags: ${normalizedTags}`);
+    lines.push(`tags: ${quoteYamlString(normalizedTags)}`);
   }
 
   lines.push('---', '');

--- a/site.v5/scripts/new-post.mjs
+++ b/site.v5/scripts/new-post.mjs
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { createInterface } from 'node:readline/promises';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const defaultRepoRoot = path.resolve(__dirname, '../..');
+
+const flagNames = new Set(['title', 'date', 'tags']);
+
+export const slugifyTitle = (title) => String(title ?? '')
+  .toLowerCase()
+  .trim()
+  .replace(/\s+/g, '-')
+  .replace(/[^\w-]+/g, '')
+  .replace(/--+/g, '-')
+  .replace(/^-+/, '')
+  .replace(/-+$/, '');
+
+const pad = (value) => String(value).padStart(2, '0');
+
+export const formatPostDate = (date = new Date()) => {
+  const offsetMinutes = -date.getTimezoneOffset();
+  const offsetSign = offsetMinutes >= 0 ? '+' : '-';
+  const offsetAbsolute = Math.abs(offsetMinutes);
+  const offsetHours = pad(Math.floor(offsetAbsolute / 60));
+  const offsetRemainder = pad(offsetAbsolute % 60);
+
+  const calendarDate =
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+  const clockTime =
+    `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+
+  return `${calendarDate} ${clockTime}${offsetSign}${offsetHours}:${offsetRemainder}`;
+};
+
+export const normalizeTags = (tags = '') => String(tags ?? '')
+  .split(',')
+  .map((tag) => tag.trim())
+  .filter(Boolean)
+  .join(', ');
+
+export const datePrefixFromPostDate = (date) => {
+  const dateString = String(date ?? '');
+  const match = dateString.match(/^(\d{4})-(\d{2})-(\d{2})(?:\s|T|$)/);
+
+  if (!match || Number.isNaN(Date.parse(dateString.replace(' ', 'T')))) {
+    throw new Error(
+      'Date must begin with YYYY-MM-DD and be parseable by JavaScript Date.',
+    );
+  }
+
+  return `${match[1]}-${match[2]}-${match[3]}`;
+};
+
+const quoteYamlString = (value) => JSON.stringify(value);
+
+export const renderPostMarkdown = ({ title, date, slug, tags }) => {
+  const normalizedTags = normalizeTags(tags);
+  const lines = [
+    '---',
+    'author: ajfisher',
+    `date: ${date}`,
+    'layout: post',
+    `slug: ${slug}`,
+    `title: ${quoteYamlString(title)}`,
+  ];
+
+  if (normalizedTags) {
+    lines.push(`tags: ${normalizedTags}`);
+  }
+
+  lines.push('---', '');
+
+  return `${lines.join('\n')}\n`;
+};
+
+export const buildPostPath = ({ repoRoot = defaultRepoRoot, date, slug }) => {
+  const datePrefix = datePrefixFromPostDate(date);
+
+  return path.join(
+    repoRoot,
+    'content',
+    'text',
+    'posts',
+    `${datePrefix}-${slug}.md`,
+  );
+};
+
+export const parseArgs = (argv) => {
+  const values = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--help' || arg === '-h') {
+      return { values, help: true };
+    }
+
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+
+    const [rawName, inlineValue] = arg.slice(2).split(/=(.*)/s, 2);
+
+    if (!flagNames.has(rawName)) {
+      throw new Error(`Unknown option: --${rawName}`);
+    }
+
+    if (inlineValue !== undefined) {
+      values[rawName] = inlineValue;
+      continue;
+    }
+
+    const nextValue = argv[index + 1];
+
+    if (!nextValue || nextValue.startsWith('--')) {
+      throw new Error(`Missing value for --${rawName}`);
+    }
+
+    values[rawName] = nextValue;
+    index += 1;
+  }
+
+  return { values, help: false };
+};
+
+export const createPost = async ({
+  repoRoot = defaultRepoRoot,
+  title,
+  date = formatPostDate(),
+  tags = '',
+}) => {
+  const trimmedTitle = String(title ?? '').trim();
+  const slug = slugifyTitle(trimmedTitle);
+
+  if (!trimmedTitle) {
+    throw new Error('Title is required.');
+  }
+
+  if (!slug) {
+    throw new Error('Title must contain at least one slug-safe character.');
+  }
+
+  const filePath = buildPostPath({ repoRoot, date, slug });
+  const markdown = renderPostMarkdown({
+    title: trimmedTitle,
+    date,
+    slug,
+    tags,
+  });
+
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+
+  try {
+    await fs.writeFile(filePath, markdown, { flag: 'wx' });
+  } catch (error) {
+    if (error && error.code === 'EEXIST') {
+      const collisionError = new Error(`Post already exists: ${filePath}`);
+      collisionError.code = 'EEXIST';
+      collisionError.filePath = filePath;
+      throw collisionError;
+    }
+
+    throw error;
+  }
+
+  return { filePath, slug };
+};
+
+const promptForValue = async (rl, label, defaultValue = '') => {
+  const suffix = defaultValue ? ` (${defaultValue})` : '';
+  const answer = await rl.question(`${label}${suffix}: `);
+  const trimmedAnswer = answer.trim();
+
+  return trimmedAnswer || defaultValue;
+};
+
+const collectOptions = async ({
+  values,
+  input = process.stdin,
+  output = process.stdout,
+  now = new Date(),
+}) => {
+  const defaults = {
+    date: formatPostDate(now),
+    tags: '',
+  };
+  const options = {
+    title: values.title,
+    date: values.date,
+    tags: values.tags,
+  };
+  const shouldPrompt = Boolean(input.isTTY && output.isTTY);
+
+  if (!shouldPrompt) {
+    return {
+      title: options.title,
+      date: options.date || defaults.date,
+      tags: options.tags || defaults.tags,
+    };
+  }
+
+  const rl = createInterface({ input, output });
+
+  try {
+    while (!options.title || !options.title.trim()) {
+      options.title = await promptForValue(rl, 'Title');
+    }
+
+    if (!options.date) {
+      options.date = await promptForValue(rl, 'Date', defaults.date);
+    }
+
+    if (options.tags === undefined) {
+      options.tags = await promptForValue(rl, 'Tags');
+    }
+
+    return options;
+  } finally {
+    rl.close();
+  }
+};
+
+const helpText = `Create a new ajfisher.me post scaffold.
+
+Usage:
+  npm run new-post
+  npm run new-post -- --title "My Post" --tags "ai, development"
+  node site.v5/scripts/new-post.mjs --title "My Post"
+
+Options:
+  --title <title>  Post title. Required in non-interactive mode.
+  --date <date>    Frontmatter date. Defaults to the current local timestamp.
+  --tags <tags>    Optional comma-separated tags.
+  -h, --help       Show this help.
+`;
+
+export const runCli = async ({
+  argv = process.argv.slice(2),
+  input = process.stdin,
+  output = process.stdout,
+  repoRoot = defaultRepoRoot,
+  now = new Date(),
+} = {}) => {
+  const { values, help } = parseArgs(argv);
+
+  if (help) {
+    output.write(helpText);
+    return 0;
+  }
+
+  const options = await collectOptions({ values, input, output, now });
+
+  if (!options.title || !options.title.trim()) {
+    throw new Error('Missing required --title in non-interactive mode.');
+  }
+
+  const result = await createPost({ repoRoot, ...options });
+  const relativePath = path.relative(process.cwd(), result.filePath);
+
+  output.write(`Created ${relativePath}\n\n`);
+  output.write('Next steps:\n');
+  output.write(`  $EDITOR ${relativePath}\n`);
+  output.write('  make dev\n');
+
+  return 0;
+};
+
+const isDirectRun = process.argv[1]
+  && pathToFileURL(process.argv[1]).href === import.meta.url;
+
+if (isDirectRun) {
+  runCli().catch((error) => {
+    process.stderr.write(`Error: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/site.v5/scripts/new-post.test.mjs
+++ b/site.v5/scripts/new-post.test.mjs
@@ -49,7 +49,7 @@ date: 2026-07-11 12:00:00+10:00
 layout: post
 slug: my-post
 title: "My Post"
-tags: ai, development
+tags: "ai, development"
 ---
 
 `,
@@ -80,10 +80,21 @@ test('builds the post path from the date and slug', () => {
   assert.equal(
     buildPostPath({
       repoRoot: '/repo',
-      date: '2026-07-11 12:00:00+10:00',
+      date: '2026-07-11 08:00:00+10:00',
       slug: 'my-post',
     }),
-    path.join('/repo', 'content', 'text', 'posts', '2026-07-11-my-post.md'),
+    path.join('/repo', 'content', 'text', 'posts', '2026-07-10-my-post.md'),
+  );
+});
+
+test('rejects invalid calendar dates', () => {
+  assert.throws(
+    () => buildPostPath({
+      repoRoot: '/repo',
+      date: '2026-02-31 12:00:00+10:00',
+      slug: 'bad-date',
+    }),
+    /valid calendar day/,
   );
 });
 

--- a/site.v5/scripts/new-post.test.mjs
+++ b/site.v5/scripts/new-post.test.mjs
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import {
+  buildPostPath,
+  createPost,
+  formatPostDate,
+  parseArgs,
+  renderPostMarkdown,
+  slugifyTitle,
+} from './new-post.mjs';
+
+test('slugifies titles using the site slug rules', () => {
+  assert.equal(
+    slugifyTitle('Fail fast, fix faster: Why faster models can beat smarter ones'),
+    'fail-fast-fix-faster-why-faster-models-can-beat-smarter-ones',
+  );
+  assert.equal(slugifyTitle("What's new in AI?"), 'whats-new-in-ai');
+});
+
+test('formats a local post date with timezone offset', () => {
+  const fakeDate = {
+    getFullYear: () => 2026,
+    getMonth: () => 6,
+    getDate: () => 11,
+    getHours: () => 12,
+    getMinutes: () => 34,
+    getSeconds: () => 56,
+    getTimezoneOffset: () => -600,
+  };
+
+  assert.equal(formatPostDate(fakeDate), '2026-07-11 12:34:56+10:00');
+});
+
+test('renders frontmatter with optional tags', () => {
+  assert.equal(
+    renderPostMarkdown({
+      title: 'My Post',
+      date: '2026-07-11 12:00:00+10:00',
+      slug: 'my-post',
+      tags: 'ai, development',
+    }),
+    `---
+author: ajfisher
+date: 2026-07-11 12:00:00+10:00
+layout: post
+slug: my-post
+title: "My Post"
+tags: ai, development
+---
+
+`,
+  );
+});
+
+test('omits the tags field when no tags are supplied', () => {
+  assert.equal(
+    renderPostMarkdown({
+      title: 'My Post',
+      date: '2026-07-11 12:00:00+10:00',
+      slug: 'my-post',
+      tags: '',
+    }),
+    `---
+author: ajfisher
+date: 2026-07-11 12:00:00+10:00
+layout: post
+slug: my-post
+title: "My Post"
+---
+
+`,
+  );
+});
+
+test('builds the post path from the date and slug', () => {
+  assert.equal(
+    buildPostPath({
+      repoRoot: '/repo',
+      date: '2026-07-11 12:00:00+10:00',
+      slug: 'my-post',
+    }),
+    path.join('/repo', 'content', 'text', 'posts', '2026-07-11-my-post.md'),
+  );
+});
+
+test('parses supported flags', () => {
+  assert.deepEqual(
+    parseArgs([
+      '--title',
+      'My Post',
+      '--date=2026-07-11 12:00:00+10:00',
+      '--tags',
+      'ai, development',
+    ]),
+    {
+      help: false,
+      values: {
+        title: 'My Post',
+        date: '2026-07-11 12:00:00+10:00',
+        tags: 'ai, development',
+      },
+    },
+  );
+});
+
+test('aborts when the derived post file already exists', async () => {
+  const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'new-post-'));
+  const existingPath = buildPostPath({
+    repoRoot,
+    date: '2026-07-11 12:00:00+10:00',
+    slug: 'my-post',
+  });
+
+  await fs.mkdir(path.dirname(existingPath), { recursive: true });
+  await fs.writeFile(existingPath, 'existing content');
+
+  await assert.rejects(
+    () => createPost({
+      repoRoot,
+      title: 'My Post',
+      date: '2026-07-11 12:00:00+10:00',
+      tags: 'ai',
+    }),
+    {
+      code: 'EEXIST',
+      filePath: existingPath,
+    },
+  );
+
+  assert.equal(await fs.readFile(existingPath, 'utf8'), 'existing content');
+});


### PR DESCRIPTION
## Summary
- Add a zero-dependency Node CLI for scaffolding new Markdown posts.
- Expose the workflow from the repo root with `npm run new-post`, plus `make post` and site-local wrappers.
- Add focused `node --test` coverage for slugging, dates, frontmatter, paths, flags, and no-overwrite collision handling.
- Harden date handling after review: filenames now use the same UTC date basis as generated post URLs, impossible dates are rejected, and tag frontmatter is YAML-quoted.

Closes #512.

## Validation
- `make test`
- `make build`
- GitHub Actions: `Build the astro site code` passed on head `63e9f57`
- Subagent code-quality review completed; follow-up review found no remaining findings.

Note: Astro check still reports existing hints about implicit types and missing `humanize-plus` declarations, but returns 0 errors and 0 warnings.