### PR TITLE
fix(seo): align search metadata and indexing signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,7 @@ make deploy
 
 For front matter schema details and content notes see
 [site.v5/README.md](site.v5/README.md).
+
+Search indexing conventions, the current legacy URL review, and Search Console
+follow-up steps are recorded in
+[docs/search-console.md](docs/search-console.md).

--- a/content/robots.txt
+++ b/content/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://ajfisher.me/sitemap-0.xml
+Sitemap: https://ajfisher.me/sitemap-index.xml

--- a/content/text/posts/2007-11-19-fuzzy-logic-could-book-more-flights.md
+++ b/content/text/posts/2007-11-19-fuzzy-logic-could-book-more-flights.md
@@ -14,7 +14,11 @@ excerpt: >
 listimage: ../../img/posts/fuzzy_flights.png 
 ---
 
-I've talked about fuzzy logic for use by the retail sector [in the past](2007/03/fuzzys-where-its-at-or-will-be) and the project I'm involved in there is maturing nicely. This week I've really realised how, as software engineers we need to grasp the nettle and move a lot of service based software toward fuzzy systems for usability reasons.
+I've talked about fuzzy logic for use by the retail sector
+[in the past](/2007/03/05/fuzzys-where-its-at-or-will-be-eventually/) and the
+project I'm involved in there is maturing nicely. This week I've really
+realised how, as software engineers we need to grasp the nettle and move a lot
+of service based software toward fuzzy systems for usability reasons.
 
 Nearly everyone these days has booked a flight online and when it came time to booking a holiday to Australia this winter, the first thing I did was fire up a browser and head to [expedia](http://www.expedia.co.uk/) and [travelocity](http://www.travelocity.co.uk/).
 

--- a/content/text/posts/2015-01-21-context-in-ambient-technology.md
+++ b/content/text/posts/2015-01-21-context-in-ambient-technology.md
@@ -1,6 +1,6 @@
 ---
 author: ajfisher
-date: 2015-01-21 10:00:00+11:00
+date: 2015-01-20 12:00:00+11:00
 layout: post
 slug: context-in-ambient-technology
 title: The role of context on ambient technologies

--- a/content/text/posts/2016-01-27-road-to-interchange.md
+++ b/content/text/posts/2016-01-27-road-to-interchange.md
@@ -1,6 +1,6 @@
 ---
 author: ajfisher
-date: 2016-01-27 10:00:00+11:00
+date: 2016-01-26 12:00:00+11:00
 layout: post.hbt
 slug: road-to-interchange
 title: The meandering journey of NodeBots Interchange
@@ -301,4 +301,3 @@ dive in further:
 * [Ping sensor](https://github.com/ajfisher/nodebots-hcsr04)
 * [How to build a nodebots backpack](https://github.com/ajfisher/interchange-arduino)
 * [Using a backpack - by Derek Wheelden](http://omit.io/2015/08/20/beginners-guide-to-backpacks/)
-

--- a/content/text/posts/2023-02-14-podcast-enterprise-ai.md
+++ b/content/text/posts/2023-02-14-podcast-enterprise-ai.md
@@ -1,6 +1,6 @@
 ---
 author: ajfisher
-date: 2023-02-13 10:00:00+11:00
+date: 2023-02-12 12:00:00+11:00
 layout: post
 slug: podcast-enterprise-ai
 title: ChatGPT and Generative AI in the enterprise

--- a/content/text/posts/2023-08-31-ai-works-now.md
+++ b/content/text/posts/2023-08-31-ai-works-now.md
@@ -1,6 +1,6 @@
 ---
 author: ajfisher
-date: 2023-08-31 10:00:00+11:00
+date: 2023-08-30 12:00:00+10:00
 layout: post
 slug: ai-works-now
 title: AI in 2023 - it works well enough now

--- a/content/text/posts/2024-01-16-retail-numbers-are-fine.md
+++ b/content/text/posts/2024-01-16-retail-numbers-are-fine.md
@@ -2,7 +2,7 @@
 title: "Retail numbers are \"fine\" (but margins less so)"
 slug: retail-numbers-are-fine
 author: ajfisher
-date: 2024-01-16 09:19:08+11:00
+date: 2024-01-15 12:00:00+11:00
 layout: post
 excerpt: >
     Retail revenues are stabilising, but heavy discounting is pulling

--- a/content/text/posts/2025-02-27-when-will-ai-disrupt-travel.md
+++ b/content/text/posts/2025-02-27-when-will-ai-disrupt-travel.md
@@ -2,7 +2,7 @@
 title: "When does travel planning get seriously upended by AI?"
 slug: when-will-ai-disrupt-travel
 author: ajfisher
-date: 2025-02-27 10:30:00+11:00
+date: 2025-02-26 12:00:00+11:00
 layout: post
 excerpt: >
     AI is everywhere in the travel industry - just not where most travellers

--- a/content/text/posts/2025-03-26-chatgpt-4o-image-generation-update.md
+++ b/content/text/posts/2025-03-26-chatgpt-4o-image-generation-update.md
@@ -2,7 +2,7 @@
 title: "ChatGPT-4o image generation improvements"
 slug: chatgpt-4o-image-generation-update
 author: ajfisher
-date: 2025-03-26 10:13:50+11:00
+date: 2025-03-25 12:00:00+11:00
 layout: post
 excerpt: >
     ChatGPT-4o's new image capabilities add multi-modal context and

--- a/content/text/posts/2025-11-20-gemini-3-initial-thoughts.md
+++ b/content/text/posts/2025-11-20-gemini-3-initial-thoughts.md
@@ -2,7 +2,7 @@
 title: "Gemini 3: initial usage thoughts"
 slug: gemini-3-initial-thoughts
 author: ajfisher
-date: 2025-11-20 09:17:07+11:00
+date: 2025-11-19 12:00:00+11:00
 layout: post
 excerpt: >
     Gemini 3 feels tighter, more consistent in long responses, and more

--- a/content/text/posts/2025-12-05-chrome-split-view-tabs.md
+++ b/content/text/posts/2025-12-05-chrome-split-view-tabs.md
@@ -2,7 +2,7 @@
 title: "Chrome finally adds split view tabs"
 slug: chrome-split-view-tabs
 author: ajfisher
-date: 2025-12-05 09:38:21+11:00
+date: 2025-12-04 12:00:00+11:00
 layout: post
 excerpt: >
     Split View for tabs arrives in Chrome, making side-by-side work and

--- a/docs/search-console.md
+++ b/docs/search-console.md
@@ -1,0 +1,186 @@
+# Search Console and search indexing
+
+This document records the July 2026 Search Console audit and the repository
+rules that follow from it. Search Console data is delayed and its example URL
+lists are samples, so counts and examples will change between crawls.
+
+## Sitemap
+
+Astro's sitemap integration generates both `sitemap-index.xml` and the child
+`sitemap-0.xml`. The index is the stable public entry point and is advertised
+in page metadata and `robots.txt`.
+
+Do not set one global `changefreq` or `priority`. Those values would apply to
+every route, making an old article look as volatile and important as the home
+page. Omitting them lets search engines infer crawl frequency from real change
+history and other signals.
+
+`https://ajfisher.me/sitemap-index.xml` was submitted to Search Console on
+16 July 2026. Google accepted the submission, but the report initially showed
+"Couldn't fetch" while it awaited processing.
+
+After deploying the repository change:
+
+1. Confirm that the sitemap index succeeds and reports discovered URLs.
+2. Remove the stale `sitemap-0.xml` submission that Search Console currently
+   reports as "Couldn't fetch".
+
+Submitting a sitemap helps discovery but does not guarantee indexing.
+
+## Canonical URLs and trailing slashes
+
+The canonical form is HTTPS on the apex domain with a trailing slash. A URL
+without its trailing slash should continue to work for people, but the ideal
+HTTP behaviour is:
+
+```text
+/path -> 301 or 308 -> /path/
+/path/ -> 200
+```
+
+No Search Console setting is required. A permanent redirect consolidates the
+signals before Search Console sees the page. The current edge handler instead
+rewrites both forms to the same S3 object, so both return `200`; the canonical
+tag then has to do the consolidation. This is valid but less clear and creates
+duplicate crawl paths.
+
+Query-string variants can remain `200` when they represent the same content,
+provided their canonical points to the clean URL. Search Console's
+"Alternative page with proper canonical tag" classification is expected for
+those URLs and is not an error.
+
+## Indexing policy
+
+"Crawled - currently not indexed" means Google fetched the URL but chose not
+to retain it in the searchable index. It is not automatically a technical
+fault. Pages can move in and out of this state as Google recrawls them,
+re-evaluates duplicates, or changes how much value it sees in an archive.
+
+The July 2026 report contained 143 such URLs. Its examples mixed older posts
+with tag archives, including `leadership`, `responsive-design`, and `nodebots`.
+
+For a URL that should be indexed, the desired state is:
+
+- one canonical URL returning `200`;
+- unique and useful content;
+- crawlable internal links from relevant pages;
+- inclusion in the sitemap; and
+- no `noindex` directive.
+
+Do not add `noindex` merely to make the exclusion report smaller. Use it only
+when the site owner has decided a page should not appear in search.
+
+### Recommended configurable model
+
+Indexing should be explicit rather than based on a blanket post-count rule:
+
+- use post count to flag thin tag archives for review;
+- default normal posts and curated tag pages to indexable;
+- support an explicit `index: false` choice for individual content or tags;
+- drive both the robots meta tag and sitemap exclusion from the same policy;
+- keep a noindexed URL crawlable until Google has observed the directive.
+
+This should be implemented as a shared search policy rather than separate
+hard-coded lists in the layout and sitemap config. No tags have been noindexed
+as part of this change.
+
+## Legacy URL review
+
+Only redirect a missing URL when there is a clear equivalent. Obsolete files
+with no replacement should remain `404` or deliberately become `410`; they
+should not redirect to the home page.
+
+| Search Console URL | Recommended outcome | Reason |
+| --- | --- | --- |
+| `/2023/02/13/podcast-enterprise-ai/` | Redirect to `/2023/02/12/podcast-enterprise-ai/` | Current canonical article |
+| `/2007/11/19/fuzzy-logic-could-book-more-flights/2007/03/fuzzys-where-its-at-or-will-be` | Redirect to `/2007/03/05/fuzzys-where-its-at-or-will-be-eventually/` | Malformed historical internal link; the source link is now fixed |
+| `/tagged/johnny-five/` | Redirect to `/tagged/nodebots/` | Closest current topic archive |
+| `/2011/12/20/` | Redirect to `/2011/12/20/towards-a-sensor-commons/` | Clear incomplete historical URL |
+| `/2011/12/20/towards-` | Redirect to `/2011/12/20/towards-a-sensor-commons/` | Clear truncated historical URL |
+| `/2007/11/27/adding-cron-jobs-to-a-qnap-server/` | Redirect to `/2007/11/26/adding-cron-jobs-to-a-qnap-server/` | Clear date variant of an existing article |
+| `/wdc/pinchzoom.html` | Retain `404` unless the demo can be restored | No current equivalent found |
+| `/wdc/multitouch.html` | Retain `404` unless the demo can be restored | No current equivalent found |
+| `/wdc/singletouch.html` | Retain `404` unless the demo can be restored | No current equivalent found |
+| `/code/deviceapi-normaliser/examples/data.html` | Retain `404` unless the demo can be restored | No current equivalent found |
+
+The redirect implementation should return a real permanent response instead
+of silently rewriting to another S3 object. It also needs unit tests before the
+Lambda@Edge function changes.
+
+## Publication dates and existing URLs
+
+Post routes are generated from UTC date components. Nine historical posts had
+a local publication date one day later than their already-deployed route. To
+avoid changing established URLs, their frontmatter dates now use a daytime
+timestamp on the route's existing calendar day.
+
+New posts should use a publication time whose UTC and intended route dates are
+the same. This avoids an unexpected previous-day route while preserving the
+current route-generation contract.
+
+## Structured data
+
+The list-item microdata previously used `itemscope="blogPost"`. In HTML,
+`itemscope` is a boolean attribute; the item type belongs in `itemtype`, and
+the relationship to the surrounding `Blog` belongs in `itemprop`.
+
+The corrected shape is:
+
+```html
+<section itemscope itemtype="https://schema.org/Blog">
+  <li
+    itemprop="blogPost"
+    itemscope
+    itemtype="https://schema.org/BlogPosting"
+  >
+    ...
+  </li>
+</section>
+```
+
+The item now also exposes its author and image, and the invalid `itemtype` on
+the abstract paragraph has been removed. A future enhancement can add complete
+`BlogPosting` JSON-LD on article detail pages, including canonical URL,
+publication/modification dates, author, headline, description, and image.
+
+## Search performance and titles
+
+Title changes should be based on relevant query intent, not aggregate CTR by
+itself. Search Console may withhold low-volume queries, and irrelevant or
+machine-generated queries can heavily distort impressions.
+
+### OpenClaw on Raspberry Pi
+
+Over the available 16-month report this article recorded 7,126 clicks from
+543,302 impressions, with 1.3% CTR and average position 7.3. From publication
+through 13 April it recorded 6,556 clicks at position 6.1; the latest three
+months recorded 570 clicks at position 11.
+
+This is consistent with first-mover demand decaying as competition grows. The
+title already expresses the core intent and should not be changed merely to
+chase the initial peak. The better maintenance strategy is to keep the guide
+accurate, add genuinely useful updates, and link to it from relevant newer
+articles. If substantive updates are made later, add a real modification date
+rather than changing the publication date.
+
+### QNAP cron article
+
+The 16-month report recorded 40 clicks from 5,676 impressions, with 0.7% CTR
+and average position 8.9. Queries are tightly aligned to `qnap cron`,
+`qnap cron job`, and `qnap crontab`. Its title already matches intent and the
+article remains a durable long-tail result. Preserve its URL and title; update
+the content only when there is verified current QNAP behaviour to add.
+
+### Other apparent title opportunities
+
+The AI-native article's 2,124 impressions are dominated by an irrelevant query
+that alone contributed 1,305 impressions. Its aggregate CTR is therefore not
+a sound reason to rewrite the title.
+
+Mercury 2 recorded 18 clicks from 3,614 impressions at average position 10.9.
+Visible relevant queries include `mercury 2 coding`, `inception mercury 2`,
+and `is mercury 2 open source`, but Search Console exposes only a small portion
+of the total query impressions. A clearer SEO title could be tested later,
+ideally through a separate `seo_title` field so the editorial headline need
+not change, but the current data does not prove a specific replacement will
+perform better.

--- a/site.v5/astro.config.mjs
+++ b/site.v5/astro.config.mjs
@@ -45,7 +45,10 @@ export default defineConfig({
   },
   integrations: [
     icon(),
-    sitemap({ changefreq: 'daily', priority: 0.7 }),
+    // Let search engines decide crawl frequency and relative priority. Applying
+    // the same values to every page makes old posts look as volatile as the
+    // homepage and does not provide a useful signal.
+    sitemap(),
     iconGenerator(),
   ],
   image: {

--- a/site.v5/src/components/ListItem.astro
+++ b/site.v5/src/components/ListItem.astro
@@ -13,6 +13,7 @@ const {
   featureimage = "",
   excerpt = "",
   date,
+  author = "ajfisher",
   readingTime = 0,
   wordCount = 0,
   compact = false,
@@ -36,12 +37,15 @@ const publishDate = (new Date(date)).toISOString().slice(0,10);
 ---
 <li
   class:list={['listitem', { compact }]}
-  itemscope="blogPost"
+  itemprop="blogPost"
+  itemscope
   itemtype="https://schema.org/BlogPosting"
 >
+  <meta itemprop="author" content={author} />
   <div>
     <a itemprop="url" href={`/${uri}`}>
       <Image src={imageTransform(image)} alt={title}
+        itemprop="image"
         layout="constrained"
         width="600" height="250" loading="lazy"/>
     </a>
@@ -55,7 +59,7 @@ const publishDate = (new Date(date)).toISOString().slice(0,10);
     <h3 itemprop="headline"><a href={`/${uri}`}>{title}</a></h3>
     <p class="postdate">
       <time itemprop="datePublished" datetime={publishDate}>{longDate(date)}</time></p>
-    <p itemprop="abstract" itemtype="https://schema.org/CreativeWork">{excerpt}</p>
+    <p itemprop="abstract">{excerpt}</p>
     <p class="postdata" aria-hidden="true">
       <meta itemprop="timeRequired" content={`PT${readingTime}M`} />
       <span>

--- a/site.v5/src/pages/blog/[...page].astro
+++ b/site.v5/src/pages/blog/[...page].astro
@@ -75,7 +75,7 @@ if (featuredPost) {
       isFeatured={true}
     />
   </Fragment>
-  <section itemtype="https://schema.org/Blog" class="list">
+  <section itemscope itemtype="https://schema.org/Blog" class="list">
     <h1>Article archive - page {page.currentPage}</h1>
     <ListItems items={posts} />
     <Pagination { ...{ page } } />

--- a/site.v5/src/pages/index.astro
+++ b/site.v5/src/pages/index.astro
@@ -50,7 +50,7 @@ const headerData = headerPost ? mergeEntryData(headerPost) : {};
       isFeatured={true}
     />
   </Fragment>
-  <section itemtype="https://schema.org/Blog" class="list home">
+  <section itemscope itemtype="https://schema.org/Blog" class="list home">
     <h1>Observations, insights, images and code from ajfisher exploring the
       intersection of AI, web, media and digital innovation.</h1>
 

--- a/site.v5/src/pages/tagged/[tag].astro
+++ b/site.v5/src/pages/tagged/[tag].astro
@@ -79,7 +79,7 @@ const seo = {
   <Fragment slot="header" { ...headerData }>
     <Header { ...headerData } largetitle={true} />
   </Fragment>
-  <section itemtype="https://schema.org/Blog" class="list">
+  <section itemscope itemtype="https://schema.org/Blog" class="list">
     <h2>Topic related posts</h2>
     <ListItems items={posts} />
   </section>


### PR DESCRIPTION
## Summary

- advertise the Astro sitemap index and remove blanket sitemap frequency/priority values
- correct Blog and BlogPosting microdata on archive and list pages
- align nine historical publication dates with their established canonical URLs without moving routes
- repair a malformed historical internal link
- document Search Console findings, indexing policy, legacy URL mappings, and future remediation options

## Why

A Search Console audit found inconsistent sitemap configuration, invalid microdata, metadata dates that did not match already-deployed URLs, and several legacy crawl paths. This PR addresses the low-risk repository fixes while preserving all existing canonical routes.

Trailing-slash redirects, legacy edge redirects, configurable noindex support, article JSON-LD, and title experiments are intentionally deferred to a separate remediation change.

## Impact

Search engines receive clearer sitemap and structured-data signals. Existing user-facing URLs and article titles remain unchanged.

The sitemap index has also been submitted to Search Console and is awaiting Google processing.

## Validation

- `make test`
- `make build`
- 210 pages built
- 209 sitemap URLs generated without blanket `changefreq` or `priority`
- verified all nine affected routes remain unchanged
- `git diff --check`