### PR TITLE
feat(seo): improve search metadata and legacy URL handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ lint:
 
 test:
 	node --test app/tests/*.test.mjs
+	node --test site.v5/tests/*.test.mjs
 	cd ./site.v5 && make test
 
 dev:

--- a/app/handlers/gatsby_index_redirect.mjs
+++ b/app/handlers/gatsby_index_redirect.mjs
@@ -1,10 +1,51 @@
-// this handler looks for requests that are effectively for directories
-// coming through cloudfront. As it doesn't know that that means to serve
-// the index file, it just throws a 404. This will perform the appropriate
-// rerouting of the URL so that S3 can retrieve the right file and respond
-// correctly.
+// This handler resolves directory-style routes to their S3 index files and
+// returns permanent responses for legacy URLs with clear replacements.
 
 const MARKDOWN_PAGE_SLUGS = new Set(['who', 'colophon', 'dis-everything']);
+
+const PERMANENT_REDIRECTS = new Map([
+  [
+    '/2023/02/13/podcast-enterprise-ai/',
+    '/2023/02/12/podcast-enterprise-ai/'
+  ],
+  [
+    '/2007/11/19/fuzzy-logic-could-book-more-flights/2007/03/' +
+      'fuzzys-where-its-at-or-will-be/',
+    '/2007/03/05/fuzzys-where-its-at-or-will-be-eventually/'
+  ],
+  ['/tagged/johnny-five/', '/tagged/nodebots/'],
+  ['/2011/12/20/', '/2011/12/20/towards-a-sensor-commons/'],
+  ['/2011/12/20/towards-/', '/2011/12/20/towards-a-sensor-commons/'],
+  [
+    '/2007/11/27/adding-cron-jobs-to-a-qnap-server/',
+    '/2007/11/26/adding-cron-jobs-to-a-qnap-server/'
+  ],
+  ['/tagged/sms/', '/tagged/mobile/'],
+  ['/tagged/data/', '/tagged/data-science/'],
+]);
+
+const redirectLookupPath = (uri = '') => {
+  if (uri.endsWith('/') || uri.includes('.')) {
+    return uri;
+  }
+
+  return `${uri}/`;
+};
+
+const permanentRedirect = (location, querystring = '') => ({
+  status: '301',
+  statusDescription: 'Moved Permanently',
+  headers: {
+    location: [{
+      key: 'Location',
+      value: querystring ? `${location}?${querystring}` : location,
+    }],
+    'cache-control': [{
+      key: 'Cache-Control',
+      value: 'public, max-age=31536000',
+    }],
+  },
+});
 
 const getHeaderValue = (headers = {}, headerName) => {
   if (!headerName) {
@@ -79,6 +120,12 @@ const ensureIndexFile = (uri, filename) => {
 export const handler = async (event) => {
   const request = event.Records[0].cf.request;
   const { uri } = request;
+  const method = request.method ?? 'GET';
+  const redirectTarget = PERMANENT_REDIRECTS.get(redirectLookupPath(uri));
+
+  if ((method === 'GET' || method === 'HEAD') && redirectTarget) {
+    return permanentRedirect(redirectTarget, request.querystring);
+  }
 
   if (uri.endsWith('%7Bauthourl%7D')) {
     // this is dealing with a bunch of the 404 errors we see where there's a
@@ -90,13 +137,6 @@ export const handler = async (event) => {
     // this is dealing with a bunch of the 404 errors we see where there's a
     // {authourl} appended to the end of the request - just remove this
     request.uri = uri.replace('{authourl}', '');
-  }
-
-  if (uri.endsWith('/tagged/sms/')) {
-    request.uri = '/tagged/mobile/';
-  }
-  if (uri.endsWith('/tagged/data/')) {
-    request.uri = '/tagged/data-science/';
   }
 
   const serveMarkdown = needsMarkdown(request.uri, request.headers);

--- a/app/tests/gatsby_index_redirect.test.mjs
+++ b/app/tests/gatsby_index_redirect.test.mjs
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { handler } from '../handlers/gatsby_index_redirect.mjs';
+
+const eventFor = (
+  uri,
+  {
+    method = 'GET',
+    querystring = '',
+    headers = {},
+  } = {}
+) => ({
+  Records: [{
+    cf: {
+      request: {
+        uri,
+        method,
+        querystring,
+        headers,
+      },
+    },
+  }],
+});
+
+const redirects = [
+  [
+    '/2023/02/13/podcast-enterprise-ai/',
+    '/2023/02/12/podcast-enterprise-ai/'
+  ],
+  [
+    '/2007/11/19/fuzzy-logic-could-book-more-flights/2007/03/' +
+      'fuzzys-where-its-at-or-will-be',
+    '/2007/03/05/fuzzys-where-its-at-or-will-be-eventually/'
+  ],
+  ['/tagged/johnny-five/', '/tagged/nodebots/'],
+  ['/2011/12/20/', '/2011/12/20/towards-a-sensor-commons/'],
+  ['/2011/12/20/towards-', '/2011/12/20/towards-a-sensor-commons/'],
+  [
+    '/2007/11/27/adding-cron-jobs-to-a-qnap-server/',
+    '/2007/11/26/adding-cron-jobs-to-a-qnap-server/'
+  ],
+  ['/tagged/sms/', '/tagged/mobile/'],
+  ['/tagged/data', '/tagged/data-science/'],
+];
+
+for (const [source, destination] of redirects) {
+  test(`permanently redirects ${source}`, async () => {
+    const response = await handler(eventFor(source));
+
+    assert.equal(response.status, '301');
+    assert.equal(response.headers.location[0].value, destination);
+    assert.equal(
+      response.headers['cache-control'][0].value,
+      'public, max-age=31536000'
+    );
+  });
+}
+
+test('preserves query strings on redirects', async () => {
+  const response = await handler(eventFor(
+    '/tagged/johnny-five/',
+    { querystring: 'source=legacy' }
+  ));
+
+  assert.equal(
+    response.headers.location[0].value,
+    '/tagged/nodebots/?source=legacy'
+  );
+});
+
+test('does not redirect unsafe request methods', async () => {
+  const request = await handler(eventFor(
+    '/tagged/johnny-five/',
+    { method: 'POST' }
+  ));
+
+  assert.equal(request.uri, '/tagged/johnny-five/index.html');
+});
+
+test('rewrites directory routes to their index file', async () => {
+  const request = await handler(eventFor('/who/'));
+
+  assert.equal(request.uri, '/who/index.html');
+});
+
+test('serves Markdown when a post requests it', async () => {
+  const request = await handler(eventFor(
+    '/2026/06/13/fail-fast-fix-faster/',
+    {
+      headers: {
+        accept: [{ value: 'text/markdown' }],
+      },
+    }
+  ));
+
+  assert.equal(
+    request.uri,
+    '/text/posts/2026-06-13-fail-fast-fix-faster.md'
+  );
+});

--- a/docs/search-console.md
+++ b/docs/search-console.md
@@ -19,11 +19,8 @@ history and other signals.
 16 July 2026. Google accepted the submission, but the report initially showed
 "Couldn't fetch" while it awaited processing.
 
-After deploying the repository change:
-
-1. Confirm that the sitemap index succeeds and reports discovered URLs.
-2. Remove the stale `sitemap-0.xml` submission that Search Console currently
-   reports as "Couldn't fetch".
+The stale direct `sitemap-0.xml` submission has been removed from Search
+Console. The index remains the only submitted sitemap.
 
 Submitting a sitemap helps discovery but does not guarantee indexing.
 
@@ -70,7 +67,7 @@ For a URL that should be indexed, the desired state is:
 Do not add `noindex` merely to make the exclusion report smaller. Use it only
 when the site owner has decided a page should not appear in search.
 
-### Recommended configurable model
+### Configurable model
 
 Indexing should be explicit rather than based on a blanket post-count rule:
 
@@ -80,9 +77,21 @@ Indexing should be explicit rather than based on a blanket post-count rule:
 - drive both the robots meta tag and sitemap exclusion from the same policy;
 - keep a noindexed URL crawlable until Google has observed the directive.
 
-This should be implemented as a shared search policy rather than separate
-hard-coded lists in the layout and sitemap config. No tags have been noindexed
-as part of this change.
+The shared search policy implements this contract. Posts and pages accept
+these optional frontmatter properties:
+
+```yaml
+seo_title: A search-specific document title
+updated: 2026-07-27
+index: false
+```
+
+`seo_title` changes the document title without changing the editorial heading.
+`updated` supplies the visible update date, sitemap `lastmod`, and structured
+data modification date. `index: false` emits `noindex, follow` and removes the
+URL from the sitemap. Tag metadata supports the same `index` property.
+
+No existing content or tags were noindexed when this model was introduced.
 
 ## Legacy URL review
 
@@ -90,7 +99,7 @@ Only redirect a missing URL when there is a clear equivalent. Obsolete files
 with no replacement should remain `404` or deliberately become `410`; they
 should not redirect to the home page.
 
-| Search Console URL | Recommended outcome | Reason |
+| Search Console URL | Redirect target or outcome | Reason |
 | --- | --- | --- |
 | `/2023/02/13/podcast-enterprise-ai/` | Redirect to `/2023/02/12/podcast-enterprise-ai/` | Current canonical article |
 | `/2007/11/19/fuzzy-logic-could-book-more-flights/2007/03/fuzzys-where-its-at-or-will-be` | Redirect to `/2007/03/05/fuzzys-where-its-at-or-will-be-eventually/` | Malformed historical internal link; the source link is now fixed |
@@ -103,9 +112,9 @@ should not redirect to the home page.
 | `/wdc/singletouch.html` | Retain `404` unless the demo can be restored | No current equivalent found |
 | `/code/deviceapi-normaliser/examples/data.html` | Retain `404` unless the demo can be restored | No current equivalent found |
 
-The redirect implementation should return a real permanent response instead
-of silently rewriting to another S3 object. It also needs unit tests before the
-Lambda@Edge function changes.
+Clear equivalents return tested `301` responses from Lambda@Edge rather than
+silently rewriting to another S3 object. The existing `sms` and `data` tag
+aliases use the same redirect mechanism.
 
 ## Publication dates and existing URLs
 
@@ -139,9 +148,15 @@ The corrected shape is:
 ```
 
 The item now also exposes its author and image, and the invalid `itemtype` on
-the abstract paragraph has been removed. A future enhancement can add complete
-`BlogPosting` JSON-LD on article detail pages, including canonical URL,
-publication/modification dates, author, headline, description, and image.
+the abstract paragraph has been removed. Article detail pages expose complete
+`BlogPosting` JSON-LD, including canonical URL, publication and optional
+modification dates, author, headline, description, and image.
+
+## Document titles
+
+The layout appends the site name exactly once. Page-level SEO titles should
+therefore contain only the page-specific portion. For example, the homepage
+uses `Home`, which renders as `Home | ajfisher`.
 
 ## Search performance and titles
 

--- a/site.v5/astro.config.mjs
+++ b/site.v5/astro.config.mjs
@@ -10,8 +10,12 @@ import remarkPullQuotes from './src/lib/remark-pullquotes.mjs';
 import remarkSlideshow from './src/lib/remark-slideshow.mjs';
 import { remarkReadingTime } from './src/lib/remark-reading-time.mjs';
 import { generateIcons } from './scripts/generate-icons.mjs';
+import { loadSearchPolicy } from './scripts/load-search-policy.mjs';
+import { createSitemapSerializer } from './src/lib/search-policy.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const contentDirectory = path.resolve(__dirname, '../content');
+const searchPolicy = await loadSearchPolicy({ contentDirectory });
 
 const iconGenerator = () => ({
   name: 'icon-generator',
@@ -48,7 +52,9 @@ export default defineConfig({
     // Let search engines decide crawl frequency and relative priority. Applying
     // the same values to every page makes old posts look as volatile as the
     // homepage and does not provide a useful signal.
-    sitemap(),
+    sitemap({
+      serialize: createSitemapSerializer(searchPolicy),
+    }),
     iconGenerator(),
   ],
   image: {

--- a/site.v5/package-lock.json
+++ b/site.v5/package-lock.json
@@ -17,7 +17,8 @@
         "humanize-plus": "^1.8.2",
         "mdast-util-to-string": "^4.0.0",
         "rehype-raw": "^7.0.0",
-        "unist-util-visit": "^5.0.0"
+        "unist-util-visit": "^5.0.0",
+        "yaml": "^2.8.2"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.6",
@@ -8525,7 +8526,6 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/site.v5/package.json
+++ b/site.v5/package.json
@@ -20,7 +20,8 @@
     "humanize-plus": "^1.8.2",
     "mdast-util-to-string": "^4.0.0",
     "rehype-raw": "^7.0.0",
-    "unist-util-visit": "^5.0.0"
+    "unist-util-visit": "^5.0.0",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.6",

--- a/site.v5/scripts/load-search-policy.mjs
+++ b/site.v5/scripts/load-search-policy.mjs
@@ -1,0 +1,78 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { parse } from 'yaml';
+
+import tagMetadata from '../../content/lib/tag_data.json' with { type: 'json' };
+import { pageUri, postUri } from '../src/lib/content-route.mjs';
+import { slugifyTag } from '../src/lib/utils.mjs';
+
+const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---/;
+
+const markdownFiles = async (directory) => {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...await markdownFiles(entryPath));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+};
+
+const readFrontmatter = async (filePath) => {
+  const source = await fs.readFile(filePath, 'utf8');
+  const match = source.match(FRONTMATTER);
+
+  if (!match) {
+    throw new Error(`Missing frontmatter in ${filePath}`);
+  }
+
+  return parse(match[1]);
+};
+
+const policyForCollection = async (directory, collection) => {
+  const policies = new Map();
+
+  for (const filePath of await markdownFiles(directory)) {
+    const data = await readFrontmatter(filePath);
+    const uri = collection === 'posts'
+      ? postUri(data.date, data.slug)
+      : pageUri(data.slug);
+
+    policies.set(`/${uri}`, {
+      index: data.index,
+      lastmod: data.updated ?? data.date,
+    });
+  }
+
+  return policies;
+};
+
+export const loadSearchPolicy = async ({ contentDirectory }) => {
+  const posts = await policyForCollection(
+    path.join(contentDirectory, 'text/posts'),
+    'posts'
+  );
+  const pages = await policyForCollection(
+    path.join(contentDirectory, 'text/pages'),
+    'pages'
+  );
+  const policies = new Map([...posts, ...pages]);
+
+  for (const metadata of tagMetadata) {
+    if (metadata.index === false) {
+      policies.set(`/tagged/${slugifyTag(metadata.tag)}/`, {
+        index: false,
+      });
+    }
+  }
+
+  return policies;
+};

--- a/site.v5/src/components/Header.astro
+++ b/site.v5/src/components/Header.astro
@@ -11,6 +11,7 @@ const {
   featureimage = '',
   excerpt = '',
   date,
+  updated,
   imageby = '',
   largetitle = false,
   smalltitle = false,
@@ -46,6 +47,9 @@ const titleClass = largetitle ? 'enlarge' : smalltitle ? 'shrink' : '';
       )}
     { typeof(date) !== 'undefined' && (
       <p class="date">Published: {longDate(date)}</p>
+    )}
+    { typeof(updated) !== 'undefined' && (
+      <p class="date">Updated: {longDate(updated)}</p>
     )}
     { readingTime > 0 && wordCount > 0 && (
       <p class="postdata">

--- a/site.v5/src/content.config.mjs
+++ b/site.v5/src/content.config.mjs
@@ -2,6 +2,7 @@ import { defineCollection } from 'astro:content';
 import { glob, _file } from 'astro/loaders';
 import { z } from 'astro/zod';
 
+import { pageUri, postUri } from './lib/content-route.mjs';
 import { slugifyTag } from './lib/utils.mjs';
 
 const buildBaseSchema = (image) => z.object({
@@ -12,6 +13,7 @@ const buildBaseSchema = (image) => z.object({
 
   // Handles the YYYY-MM-dd hh:mm:ss+tz format automatically
   date: z.coerce.date(),
+  updated: z.coerce.date().optional(),
   author: z.string().optional().default('ajfisher'),
 
   // Requirement: enum
@@ -19,6 +21,8 @@ const buildBaseSchema = (image) => z.object({
 
   excerpt: z.string().optional(),
   twitter_excerpt: z.string().optional(),
+  seo_title: z.string().optional(),
+  index: z.boolean().optional().default(true),
 
   // image path
   featureimage: image().optional(),
@@ -53,14 +57,9 @@ const buildBaseSchema = (image) => z.object({
 const posts = defineCollection({
   loader: glob({ pattern: "**/*.md", base: "./../content/text/posts" }),
   schema: ({ image }) => buildBaseSchema(image).transform((data) => {
-    const d = data.date;
-    const y = d.getUTCFullYear();
-    const m = String(d.getUTCMonth() + 1).padStart(2, '0');
-    const day = String(d.getUTCDate()).padStart(2, '0');
-
     return {
       ...data,
-      uri: `${y}/${m}/${day}/${data.slug}/`
+      uri: postUri(data.date, data.slug)
     };
   }),
 });
@@ -71,7 +70,7 @@ const pages = defineCollection({
     return {
       ...data,
       // Pages just get the top-level slug
-      uri: `${data.slug}/`
+      uri: pageUri(data.slug)
     };
   }),
 });

--- a/site.v5/src/layouts/BaseLayout.astro
+++ b/site.v5/src/layouts/BaseLayout.astro
@@ -11,6 +11,7 @@ import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
 import { imageTransform } from '../lib/utils.mjs';
 import { ICON_SIZES, faviconPath, iconPath } from '../lib/icon-meta.mjs';
+import { documentTitle, robotsContent } from '../lib/search-policy.mjs';
 import { SITE_META } from '../lib/site-meta.mjs';
 
 const {
@@ -22,13 +23,17 @@ const {
 } = Astro.props;
 
 const siteUrl = Astro.site ?? SITE_META.siteUrl;
-const pageTitle = seo.title ?? rawTitle ?? SITE_META.defaultTitle;
-const description = seo.description ?? SITE_META.description;
+const pageTitle = String(
+  seo.title ?? rawTitle ?? SITE_META.defaultTitle
+).trim();
+const browserTitle = String(seo.documentTitle ?? pageTitle).trim();
+const description = String(seo.description ?? SITE_META.description).trim();
 const pageType = seo.type ?? 'post';
 const tweet = seo.tweet ?? '';
 const readingTime = seo.readingTime ?? 0;
 const words = seo.words ?? 0;
 const extraMeta = Array.isArray(seo.meta) ? seo.meta : [];
+const robots = robotsContent(seo.index);
 
 const resolveImagePath = (value) => {
   if (!value) return undefined;
@@ -46,10 +51,7 @@ const optimisedImage = await getImage({
 }).catch(() => null);
 const imageUrl = optimisedImage?.src && siteUrl ? new URL(optimisedImage.src, siteUrl).toString() : undefined;
 
-let titleTag = pageTitle || SITE_META.defaultTitle;
-if (titleTag !== SITE_META.defaultTitle) {
-  titleTag = `${titleTag} | ${SITE_META.defaultTitle}`;
-}
+const titleTag = documentTitle(browserTitle, SITE_META.defaultTitle);
 
 const cardMeta = [];
 
@@ -85,6 +87,33 @@ const metaTags = [
 const canonical = siteUrl ? new URL(Astro.url.pathname, siteUrl).toString() : undefined;
 const sitemapUrl = siteUrl ? new URL('/sitemap-index.xml', siteUrl).toString() : '/sitemap-index.xml';
 const rssUrl = siteUrl ? new URL('/rss.xml', siteUrl).toString() : '/rss.xml';
+const structuredAuthor = seo.structuredData?.author === 'ajfisher'
+  ? {
+      '@type': 'Person',
+      name: SITE_META.authorName,
+      url: new URL('/who/', siteUrl).toString(),
+    }
+  : {
+      '@type': 'Person',
+      name: seo.structuredData?.author,
+    };
+const structuredData = seo.structuredData?.type === 'BlogPosting' && canonical ? {
+  '@context': 'https://schema.org',
+  '@type': 'BlogPosting',
+  headline: seo.structuredData.headline.trim(),
+  description,
+  url: canonical,
+  mainEntityOfPage: canonical,
+  author: structuredAuthor,
+  datePublished: new Date(seo.structuredData.datePublished).toISOString(),
+  ...(seo.structuredData.dateModified && {
+    dateModified: new Date(seo.structuredData.dateModified).toISOString(),
+  }),
+  ...(imageUrl && { image: imageUrl }),
+} : undefined;
+const structuredDataJson = structuredData
+  ? JSON.stringify(structuredData).replaceAll('<', '\\u003c')
+  : undefined;
 ---
 <html lang="en">
   <head>
@@ -101,7 +130,15 @@ const rssUrl = siteUrl ? new URL('/rss.xml', siteUrl).toString() : '/rss.xml';
     <link rel="sitemap" type="application/xml" title="Sitemap" href={sitemapUrl} />
     <link rel="alternate" type="application/rss+xml" title="RSS" href={rssUrl} />
     {markdownHref && <link rel="alternate" type="text/markdown" href={markdownHref} />}
+    {robots && <meta name="robots" content={robots} />}
     {metaTags.map((tag) => <meta {...tag} />)}
+    {structuredDataJson && (
+      <script
+        is:inline
+        type="application/ld+json"
+        set:html={structuredDataJson}
+      ></script>
+    )}
     { import.meta.env.PROD && (
       <Fragment>
         <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-CPBBDZJVXJ"></script>

--- a/site.v5/src/lib/content-route.mjs
+++ b/site.v5/src/lib/content-route.mjs
@@ -1,0 +1,10 @@
+export const postUri = (dateValue, slug) => {
+  const date = new Date(dateValue);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+
+  return `${year}/${month}/${day}/${slug}/`;
+};
+
+export const pageUri = (slug) => `${slug}/`;

--- a/site.v5/src/lib/search-policy.mjs
+++ b/site.v5/src/lib/search-policy.mjs
@@ -1,0 +1,36 @@
+export const isIndexable = (value) => value !== false;
+
+export const robotsContent = (value) =>
+  isIndexable(value) ? undefined : 'noindex, follow';
+
+export const documentTitle = (title, siteTitle) => {
+  const normalizedTitle = title?.trim();
+
+  if (!normalizedTitle || normalizedTitle === siteTitle) {
+    return siteTitle;
+  }
+
+  if (normalizedTitle.endsWith(` | ${siteTitle}`)) {
+    return normalizedTitle;
+  }
+
+  return `${normalizedTitle} | ${siteTitle}`;
+};
+
+export const createSitemapSerializer = (policyByPath) => (item) => {
+  const pathname = new URL(item.url).pathname;
+  const policy = policyByPath.get(pathname);
+
+  if (policy && !isIndexable(policy.index)) {
+    return undefined;
+  }
+
+  if (policy?.lastmod) {
+    return {
+      ...item,
+      lastmod: new Date(policy.lastmod).toISOString(),
+    };
+  }
+
+  return item;
+};

--- a/site.v5/src/lib/site-meta.mjs
+++ b/site.v5/src/lib/site-meta.mjs
@@ -2,5 +2,6 @@ export const SITE_META = {
   defaultTitle: 'ajfisher',
   description: 'The blog and portfolio of AJFisher - technologist',
   author: '@ajfisher',
+  authorName: 'AJ Fisher',
   siteUrl: 'https://ajfisher.me',
 };

--- a/site.v5/src/pages/[...path].astro
+++ b/site.v5/src/pages/[...path].astro
@@ -67,12 +67,21 @@ entry.data.wordCount = remarkPluginFrontmatter.wordCount;
 
 const seo = {
   title: entry.data.title,
+  documentTitle: entry.data.seo_title || entry.data.title,
   description: excerpt,
   type: 'article',
   tweet: twitterExcerpt,
   image: isPost ? entry.data.featureimage : undefined,
   readingTime: isPost ? entry.data.readingTime : 0,
   words: isPost ? entry.data.wordCount : 0,
+  index: entry.data.index,
+  structuredData: isPost ? {
+    type: 'BlogPosting',
+    headline: entry.data.title,
+    author: entry.data.author,
+    datePublished: entry.data.date,
+    dateModified: entry.data.updated,
+  } : undefined,
 };
 const hasSlideshow = Boolean(remarkPluginFrontmatter.hasSlideshow);
 const markdownHref = buildMarkdownHref(entry.data, entry.collection);

--- a/site.v5/src/pages/index.astro
+++ b/site.v5/src/pages/index.astro
@@ -36,7 +36,7 @@ const headerPost = featured[0];
 featured = featured.slice(1, 3);
 
 const seo = {
-  title: 'Home | ajfisher',
+  title: 'Home',
   description: 'Explore insights on technology, business and user experience at the intersection of AI, web, media and digital innovation.',
   type: 'list',
 };

--- a/site.v5/src/pages/tagged/[tag].astro
+++ b/site.v5/src/pages/tagged/[tag].astro
@@ -72,6 +72,7 @@ const seo = {
   title: `${tagTitle} tagged posts`,
   description: `Posts that are tagged ${tagName} on ajfisher.me`,
   type: 'list',
+  index: metadata.index,
 };
 
 ---

--- a/site.v5/tests/search-policy.test.mjs
+++ b/site.v5/tests/search-policy.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  createSitemapSerializer,
+  documentTitle,
+  robotsContent,
+} from '../src/lib/search-policy.mjs';
+
+test('adds the site title exactly once', () => {
+  assert.equal(documentTitle('Home', 'ajfisher'), 'Home | ajfisher');
+  assert.equal(documentTitle('Home\n', 'ajfisher'), 'Home | ajfisher');
+  assert.equal(
+    documentTitle('Home | ajfisher', 'ajfisher'),
+    'Home | ajfisher'
+  );
+  assert.equal(documentTitle('ajfisher', 'ajfisher'), 'ajfisher');
+});
+
+test('only emits robots metadata for explicitly excluded pages', () => {
+  assert.equal(robotsContent(undefined), undefined);
+  assert.equal(robotsContent(true), undefined);
+  assert.equal(robotsContent(false), 'noindex, follow');
+});
+
+test('omits noindex pages and applies content modification dates', () => {
+  const policies = new Map([
+    ['/private/', { index: false }],
+    ['/updated/', { lastmod: '2026-07-27T00:00:00.000Z' }],
+  ]);
+  const serialize = createSitemapSerializer(policies);
+
+  assert.equal(
+    serialize({ url: 'https://ajfisher.me/private/' }),
+    undefined
+  );
+  assert.deepEqual(
+    serialize({ url: 'https://ajfisher.me/updated/' }),
+    {
+      url: 'https://ajfisher.me/updated/',
+      lastmod: '2026-07-27T00:00:00.000Z',
+    }
+  );
+});


### PR DESCRIPTION
## Summary

- fix document-title composition so the site name is appended exactly once
- return permanent redirects for legacy URLs with clear current equivalents
- add configurable `seo_title`, `updated`, and `index` content metadata
- drive robots directives and sitemap inclusion from the same indexing policy
- add sitemap modification dates and `BlogPosting` JSON-LD
- document the Search Console remediation model and add regression tests

## Why

Search Console identified duplicated homepage branding, historical 404s with unambiguous replacements, and a need for explicit indexing decisions. The site previously composed titles at multiple levels, silently rewrote some legacy tag URLs, and did not have one shared model for robots metadata, sitemap inclusion, modification dates, and article structured data.

## Impact

Existing content remains indexable by default and no content or tags are blanket-noindexed. Editors can opt into search-specific titles, modification dates, or exclusion through frontmatter. Clear legacy URLs now communicate their canonical replacement with a real 301 response.

OpenClaw and QNAP content changes are intentionally deferred.

## Validation

- `make build`
  - 17 Node tests passed
  - Astro check: 0 errors
  - 210 pages built
  - sitemap index generated
- verified generated homepage title is `Home | ajfisher`
- verified generated article `BlogPosting` JSON-LD and sitemap `lastmod`

Closes #525
Closes #526
Closes #527