### PR TITLE
fix(search): canonicalise URLs and repair internal link

### DIFF
--- a/app/handlers/gatsby_index_redirect.mjs
+++ b/app/handlers/gatsby_index_redirect.mjs
@@ -47,6 +47,16 @@ const permanentRedirect = (location, querystring = '') => ({
   },
 });
 
+const isRedirectMethod = (method) => method === 'GET' || method === 'HEAD';
+
+const trailingSlashTarget = (uri = '') => {
+  if (!uri || uri === '/' || uri.endsWith('/') || uri.includes('.')) {
+    return undefined;
+  }
+
+  return `${uri}/`;
+};
+
 const getHeaderValue = (headers = {}, headerName) => {
   if (!headerName) {
     return '';
@@ -123,7 +133,7 @@ export const handler = async (event) => {
   const method = request.method ?? 'GET';
   const redirectTarget = PERMANENT_REDIRECTS.get(redirectLookupPath(uri));
 
-  if ((method === 'GET' || method === 'HEAD') && redirectTarget) {
+  if (isRedirectMethod(method) && redirectTarget) {
     return permanentRedirect(redirectTarget, request.querystring);
   }
 
@@ -137,6 +147,11 @@ export const handler = async (event) => {
     // this is dealing with a bunch of the 404 errors we see where there's a
     // {authourl} appended to the end of the request - just remove this
     request.uri = uri.replace('{authourl}', '');
+  }
+
+  const canonicalTarget = trailingSlashTarget(request.uri);
+  if (isRedirectMethod(method) && canonicalTarget) {
+    return permanentRedirect(canonicalTarget, request.querystring);
   }
 
   const serveMarkdown = needsMarkdown(request.uri, request.headers);

--- a/app/tests/gatsby_index_redirect.test.mjs
+++ b/app/tests/gatsby_index_redirect.test.mjs
@@ -78,6 +78,33 @@ test('does not redirect unsafe request methods', async () => {
   assert.equal(request.uri, '/tagged/johnny-five/index.html');
 });
 
+test('redirects extensionless routes to their trailing-slash canonical', async () => {
+  for (const method of ['GET', 'HEAD']) {
+    const response = await handler(eventFor('/who', { method }));
+
+    assert.equal(response.status, '301');
+    assert.equal(response.headers.location[0].value, '/who/');
+  }
+});
+
+test('keeps explicit legacy redirects ahead of slash canonicalisation', async () => {
+  const response = await handler(eventFor('/tagged/data'));
+
+  assert.equal(response.status, '301');
+  assert.equal(
+    response.headers.location[0].value,
+    '/tagged/data-science/'
+  );
+});
+
+test('does not canonicalise file paths or unsafe methods', async () => {
+  const fileRequest = await handler(eventFor('/sitemap-index.xml'));
+  const postRequest = await handler(eventFor('/who', { method: 'POST' }));
+
+  assert.equal(fileRequest.uri, '/sitemap-index.xml');
+  assert.equal(postRequest.uri, '/who/index.html');
+});
+
 test('rewrites directory routes to their index file', async () => {
   const request = await handler(eventFor('/who/'));
 

--- a/content/text/posts/2026-06-13-fail-fast-fix-faster.md
+++ b/content/text/posts/2026-06-13-fail-fast-fix-faster.md
@@ -50,7 +50,7 @@ slow?](../../img/posts/presentations/aieng26/brain-bunny-tradeoff-background-v2.
 *Does smart mean slow? (cc) ajfisher - ChatGPT Images 2.0*
 
 For [a while now I've had this
-idea](../posts/2026-02-26-mercury-2-diffusion-agents.md) that instead of
+idea](/2026/02/26/mercury-2-diffusion-agents/) that instead of
 focussing on how well a model performs a task, what happens when a model gets
 good enough you expect it to succeed, and instead, benefit lies in how quickly
 can it achieve a result.

--- a/docs/search-console.md
+++ b/docs/search-console.md
@@ -27,19 +27,18 @@ Submitting a sitemap helps discovery but does not guarantee indexing.
 ## Canonical URLs and trailing slashes
 
 The canonical form is HTTPS on the apex domain with a trailing slash. A URL
-without its trailing slash should continue to work for people, but the ideal
-HTTP behaviour is:
+without its trailing slash continues to work for people through a permanent
+redirect:
 
 ```text
 /path -> 301 or 308 -> /path/
 /path/ -> 200
 ```
 
-No Search Console setting is required. A permanent redirect consolidates the
-signals before Search Console sees the page. The current edge handler instead
-rewrites both forms to the same S3 object, so both return `200`; the canonical
-tag then has to do the consolidation. This is valid but less clear and creates
-duplicate crawl paths.
+No Search Console setting is required. The edge handler returns the redirect
+before rewriting the canonical path to its S3 object, consolidating signals
+before Search Console sees the page. File-like paths and the site root are not
+affected.
 
 Query-string variants can remain `200` when they represent the same content,
 provided their canonical points to the clean URL. Search Console's

--- a/site.v5/tests/content-links.test.mjs
+++ b/site.v5/tests/content-links.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const contentDirectory = path.resolve(__dirname, '../../content/text');
+const relativeMarkdownLink =
+  /(?<!!)\[[^\]]*\]\((?:\.\.?\/)[^)\s]+\.md(?:#[^)]*)?\)/g;
+
+const markdownFiles = async (directory) => {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...await markdownFiles(entryPath));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+};
+
+test('content does not link to repository-relative Markdown files', async () => {
+  const failures = [];
+
+  for (const filePath of await markdownFiles(contentDirectory)) {
+    const source = await fs.readFile(filePath, 'utf8');
+    const matches = source.match(relativeMarkdownLink) ?? [];
+
+    for (const match of matches) {
+      failures.push(`${path.relative(contentDirectory, filePath)}: ${match}`);
+    }
+  }
+
+  assert.deepEqual(failures, []);
+});


### PR DESCRIPTION
## Summary

- permanently redirect extensionless slashless URLs to their trailing-slash canonical
- retain explicit legacy redirect precedence, Markdown negotiation, file paths, and unsafe-method handling
- replace the malformed repository-relative Mercury article link with its published canonical URL
- add regression coverage for edge canonicalisation and relative Markdown content links
- update the Search Console remediation documentation

## Why

CloudFront previously served both `/path` and `/path/` as `200`, leaving canonical tags to consolidate duplicate crawl paths. Separately, one repository-relative `.md` link was emitted unchanged and resolved beneath the current article URL, producing a Search Console 404.

## Impact

People using slashless page URLs are permanently redirected to the canonical trailing-slash form. Static files and explicit legacy mappings are unaffected. The broken article link now resolves to the published Mercury 2 post, and future repository-relative Markdown links will fail the test suite.

The current CloudFront cache policy does not forward query strings to the origin-request Lambda, so slash canonicalisation does not attempt to preserve them in production.

## Validation

- `make build`
  - 21 Node tests passed
  - Astro check: 0 errors
  - 211 pages built
  - sitemap index generated
- verified the generated Fail Fast article contains the canonical Mercury URL
- `git diff --check`

Closes #532
Closes #533