### PR TITLE
fix: catch relative markdown content links

### DIFF
--- a/content/text/posts/2026-06-13-fail-fast-fix-faster.md
+++ b/content/text/posts/2026-06-13-fail-fast-fix-faster.md
@@ -50,7 +50,7 @@ slow?](../../img/posts/presentations/aieng26/brain-bunny-tradeoff-background-v2.
 *Does smart mean slow? (cc) ajfisher - ChatGPT Images 2.0*
 
 For [a while now I've had this
-idea](../posts/2026-02-26-mercury-2-diffusion-agents.md) that instead of
+idea](/2026/02/26/mercury-2-diffusion-agents/) that instead of
 focussing on how well a model performs a task, what happens when a model gets
 good enough you expect it to succeed, and instead, benefit lies in how quickly
 can it achieve a result.

--- a/site.v5/tests/content-links.test.mjs
+++ b/site.v5/tests/content-links.test.mjs
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..'
+);
+const contentDirs = [
+  path.join(repoRoot, 'content/text/pages'),
+  path.join(repoRoot, 'content/text/posts'),
+];
+
+async function markdownFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map((entry) => {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        return markdownFiles(fullPath);
+      }
+      return entry.isFile() && entry.name.endsWith('.md') ? [fullPath] : [];
+    })
+  );
+  return files.flat();
+}
+
+function stripHashAndQuery(href) {
+  return href.split(/[?#]/, 1)[0];
+}
+
+function isPublicOrExternalHref(href) {
+  return (
+    href.startsWith('/') ||
+    href.startsWith('#') ||
+    /^[a-z][a-z0-9+.-]*:/i.test(href)
+  );
+}
+
+function markdownLinkHrefs(content) {
+  return [
+    ...content.matchAll(/!?\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g),
+    ...content.matchAll(/^\s*\[[^\]]+\]:\s*(\S+)/gm),
+  ].map((match) => match[1].replace(/^<|>$/g, ''));
+}
+
+test('content links do not point to repository Markdown files', async () => {
+  const violations = [];
+  for (const dir of contentDirs) {
+    for (const file of await markdownFiles(dir)) {
+      const content = await readFile(file, 'utf8');
+      for (const href of markdownLinkHrefs(content)) {
+        if (
+          !isPublicOrExternalHref(href) &&
+          stripHashAndQuery(href).endsWith('.md')
+        ) {
+          violations.push(`${path.relative(repoRoot, file)} -> ${href}`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});


### PR DESCRIPTION
## Summary
- Replace the repository-relative Markdown link in the Fail fast, fix faster article with the canonical published Mercury 2 article URL.
- Add a Node test that scans post/page content for repository-relative `.md` links before deployment.
- Keep public absolute Markdown URLs such as `/text/...md` allowed.

## Why
Fixes #533.

## Verification
- `node --test site.v5/tests/content-links.test.mjs`
- `rg -n "\\]\\((\\.\\.?/[^)]*|[^:/)#][^)]*)\\.md(?:[?#][^)]*)?\\)" content/text/posts content/text/pages` (no matches)
- `npm ci` from `site.v5/`
- `make test`
- `make build`
